### PR TITLE
[codex] Project運用文書を追加

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,38 @@
+# Project Agent Instructions
+
+## Project
+
+- NO-Houchi Bicycle Net is a civic-tech prototype monorepo for abandoned bicycle reporting, owner unlock flow, recovery operations, and related documentation.
+- Keep prototype scope separate from future ideas such as advanced analytics, blacklist handling, detailed incentive design, and external integrations.
+- Prefer repository docs for durable project facts; do not put repo-specific details in global memory.
+
+## Structure
+
+- `backend/`: Fastify + Prisma API server and backend tests.
+- `apps/owner-web/`: Next.js owner-facing web app, API mocks, Jest tests, and Playwright tests.
+- `docs/`: design, setup, API, data model, acceptance, workflow, and status documents.
+- `apps/android-app/` and `apps/admin-dashboard/` are described in project docs, but may not exist or may be incomplete in the current tree.
+
+## Commands
+
+- Backend setup and dev: `cd backend && npm install && docker-compose up -d && npm run prisma:generate && npm run prisma:migrate && npm run dev`
+- Backend tests: `cd backend && npm test`
+- Owner web dev: `cd apps/owner-web && npm install && npm run dev`
+- Owner web checks: `cd apps/owner-web && npm test && npm run type-check && npm run lint`
+- Owner web E2E: `cd apps/owner-web && npm run e2e`
+
+## Workflow
+
+- Read `README.md` and `docs/developer-workflow.md` before changing setup, verification, or repo structure.
+- For API or data changes, inspect `docs/api-spec.md`, `docs/owner-api.md`, `docs/data-model.md`, `docs/openapi*.yaml`, and `backend/prisma/schema.prisma`.
+- This repo intentionally has no CI; use local verification and report commands that were not run.
+- For broad or multi-session work, create `plan/YYYY-MM-DD__task-slug.md`.
+- Before finishing broad changes, check whether `AGENTS.md`, `ARCHITECTURE.md`, or `plan/README.md` should be updated.
+- Move durable project facts discovered during work into project docs instead of relying on chat history.
+
+## Verification
+
+- Documentation-only changes can use static review and `git diff`.
+- Backend behavior changes should usually run `cd backend && npm test`.
+- Owner web behavior changes should usually run `cd apps/owner-web && npm test && npm run type-check`.
+- Run Playwright E2E only when owner flow behavior or browser integration changes.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,38 @@
+# Architecture
+
+## Overview
+
+NO-Houchi Bicycle Net is a monorepo for a prototype civic-tech platform targeting abandoned bicycle operations in Osaka Kita Ward. The current design centers on reporting, owner warning and unlock actions, recovery requests, and recovery result recording.
+
+## Current Components
+
+- `backend/`: TypeScript Fastify API server with Prisma models, migrations, routes, services, and Vitest tests.
+- `apps/owner-web/`: Next.js owner web flow for marker pages, temporary unlock, final unlock, mocks, unit tests, and Playwright tests.
+- `docs/`: source documents for setup, developer workflow, API specs, owner API, data model, acceptance criteria, wireframes, and project status.
+- `README.md`: high-level project scope, monorepo shape, setup notes, and prototype/future-scope distinction.
+
+## Main Flows
+
+- Supporter/reporting flow: abandoned bicycle information is recorded through backend APIs and data models.
+- Owner flow: a marker code opens owner web pages, then temporary unlock and final unlock actions are handled through owner-facing routes and backend/API mock paths.
+- Recovery operations: unresolved cases can move toward recovery request and recovery result tracking according to the design docs.
+- Coupon/OCR features exist in backend documentation and code and should be checked against current implementation before changing behavior.
+
+## Boundaries
+
+- `backend/prisma/schema.prisma` is the source of truth for implemented database model names and relations.
+- API documentation should be updated with API behavior changes; do not leave docs and route behavior intentionally divergent.
+- CI is not used by project policy. Verification is local and should be documented in PR notes or task plans.
+- Prototype scope should remain distinct from future-scope features.
+
+## Maintenance
+
+- Update this file when components, major flows, data boundaries, or prototype/future-scope decisions change.
+- Update `AGENTS.md` when setup, commands, verification, or repository operating rules change.
+- Prefer short, current descriptions over historical detail; move task-specific notes into `plan/`.
+
+## Unknowns
+
+- Current status of `apps/android-app/` and `apps/admin-dashboard/` in the implementation tree.
+- Final production infrastructure and external integration choices.
+- Which future-scope features will be promoted into prototype scope.

--- a/plan/README.md
+++ b/plan/README.md
@@ -1,0 +1,24 @@
+# Plan Files
+
+Use `plan/YYYY-MM-DD__task-slug.md` for broad, risky, or multi-session work.
+
+Good uses:
+
+- changing API contracts, data models, or Prisma migrations
+- changing owner unlock, coupon, OCR, or recovery flows
+- adding or restructuring app directories
+- updating multiple docs to match implementation
+- introducing local verification scripts or workflow changes
+
+Include:
+
+- goal and non-goals
+- files and docs inspected
+- planned changes
+- verification commands
+- data/API assumptions
+- risks and follow-ups
+- whether `AGENTS.md` or `ARCHITECTURE.md` need updates
+
+Do not create a plan file for small typo fixes or narrow documentation edits.
+When a plan produces durable project knowledge, update `AGENTS.md` or `ARCHITECTURE.md` before closing the task.


### PR DESCRIPTION
## 概要

- `AGENTS.md` を追加し、repo固有の構成、確認済みコマンド、ローカル検証方針、project docs更新ルールを整理しました。
- `ARCHITECTURE.md` を追加し、主要コンポーネント、主要フロー、境界、Maintenance、Unknownsを整理しました。
- `plan/README.md` を追加し、広い変更や複数セッション作業でのplan運用を定義しました。

## 目的

NO-Houchi Bicycle Net の進行に合わせて、プロジェクト説明・構造説明・作業計画が継続的に更新される体制を作るためです。

## 確認

- 対象ファイルの存在確認
- 末尾空白チェック
- `git diff --cached --check`

ドキュメントのみの変更のため、テストやビルドは実行していません。