### PR TITLE
[codex] PR作成まで進める運用ルールを追加

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,6 +32,7 @@
 
 ## Verification
 
+- Unless the user explicitly stops before PR work, continue through verification, diff review, commit, push, and PR creation.
 - Documentation-only changes can use static review and `git diff`.
 - Backend behavior changes should usually run `cd backend && npm test`.
 - Owner web behavior changes should usually run `cd apps/owner-web && npm test && npm run type-check`.


### PR DESCRIPTION
## 概要
- `AGENTS.md` の検証ルールに、ユーザーが明示的に止めない限りPR作成まで進める方針を追加しました。
- 検証、差分確認、commit、push、PR作成までを通常の完了範囲として明記しました。

## 影響
- 今後のCodex作業で、実装やリポジトリ変更後の公開作業まで自動で進めやすくなります。

## 確認
- `git diff -- AGENTS.md` で差分を確認しました。
- 文書変更のみのため、テスト・lint・buildは未実施です。