### PR TITLE
[codex] ADRテンプレート運用を追加

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,6 +5,7 @@
 - NO-Houchi Bicycle Net is a civic-tech prototype monorepo for abandoned bicycle reporting, owner unlock flow, recovery operations, and related documentation.
 - Keep prototype scope separate from future ideas such as advanced analytics, blacklist handling, detailed incentive design, and external integrations.
 - Prefer repository docs for durable project facts; do not put repo-specific details in global memory.
+- Put durable architecture, data model, external service, security, or operations decisions in `docs/adr/`.
 
 ## Structure
 
@@ -28,7 +29,7 @@
 - This repo intentionally has no CI; use local verification and report commands that were not run.
 - For GitHub Project or Issue management, read `docs/project-management.md` and keep Issue state and Project Status synchronized.
 - For broad or multi-session work, create `plan/YYYY-MM-DD__task-slug.md`.
-- Before finishing broad changes, check whether `AGENTS.md`, `ARCHITECTURE.md`, or `plan/README.md` should be updated.
+- Before finishing broad changes, check whether `AGENTS.md`, `ARCHITECTURE.md`, `docs/adr/`, or `plan/README.md` should be updated.
 - Move durable project facts discovered during work into project docs instead of relying on chat history.
 
 ## Verification

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -29,6 +29,7 @@ NO-Houchi Bicycle Net is a monorepo for a prototype civic-tech platform targetin
 
 - Update this file when components, major flows, data boundaries, or prototype/future-scope decisions change.
 - Update `AGENTS.md` when setup, commands, verification, or repository operating rules change.
+- Create or update an ADR in `docs/adr/` when a long-lived architecture, data model, external service, security, or operations decision should guide future work.
 - Prefer short, current descriptions over historical detail; move task-specific notes into `plan/`.
 
 ## Unknowns

--- a/docs/adr/YYYY-MM-DD__decision-slug.md
+++ b/docs/adr/YYYY-MM-DD__decision-slug.md
@@ -1,0 +1,34 @@
+# Architecture Decision Record
+
+## Status
+
+- Proposed
+
+Allowed values: Proposed, Accepted, Superseded, Deprecated.
+
+## Context
+
+- What decision needs to be made:
+- Why this matters now:
+- Constraints:
+
+## Decision
+
+- TBD
+
+## Consequences
+
+- Positive:
+- Negative:
+- Follow-up work:
+
+## Alternatives Considered
+
+- Option:
+- Reason not chosen:
+
+## Related
+
+- Plan:
+- Pull request:
+- Supersedes:

--- a/plan/README.md
+++ b/plan/README.md
@@ -18,7 +18,8 @@ Include:
 - verification commands
 - data/API assumptions
 - risks and follow-ups
-- whether `AGENTS.md` or `ARCHITECTURE.md` need updates
+- whether `AGENTS.md`, `ARCHITECTURE.md`, or `docs/adr/` need updates
 
 Do not create a plan file for small typo fixes or narrow documentation edits.
 When a plan produces durable project knowledge, update `AGENTS.md` or `ARCHITECTURE.md` before closing the task.
+When a plan produces an accepted long-lived decision, record it in `docs/adr/`.


### PR DESCRIPTION
## 概要

- `docs/adr/YYYY-MM-DD__decision-slug.md` を追加しました。
- 長く残すべきアーキテクチャ、データモデル、外部サービス、セキュリティ、運用上の意思決定をADRに記録する方針を `AGENTS.md`、`ARCHITECTURE.md`、`plan/README.md` に反映しました。

## 確認内容

- `rg -n "docs/adr|ADR|Architecture Decision" AGENTS.md ARCHITECTURE.md plan/README.md docs/adr/YYYY-MM-DD__decision-slug.md`
- `rg -n "[ \\t]+$" AGENTS.md ARCHITECTURE.md plan/README.md docs/adr/YYYY-MM-DD__decision-slug.md`
- `git diff --check`

## 補足

Markdownのみの変更のため、アプリケーションテスト、lint、typecheck、buildは実行していません。