### PR TITLE
バックエンドの責務分離リファクタリング

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -40,10 +40,10 @@ curl -X POST http://localhost:3000/owner/markers/ABC123/unlock-temp \
   -H "Content-Type: application/json" \
   -d '{"notes": "自転車を移動しました"}'
 
-# 2. 本解除（15分後、クーポン発行）
+# 2. 本解除（15分後、QR再スキャン照合のうえクーポン発行）
 curl -X POST http://localhost:3000/owner/markers/ABC123/unlock-final \
   -H "Content-Type: application/json" \
-  -d '{"ownerEmail": "owner@example.com"}'
+  -d '{"scannedCode": "ABC123", "ownerEmail": "owner@example.com"}'
 
 # レスポンス例
 {
@@ -111,7 +111,7 @@ curl -X POST http://localhost:3000/bikes/ocr/recognize \
 ### 仕様
 
 - **入力**: ローカルファイルパス（FTPから事前取得したJPG/PNG画像）
-- **出力**: 防犯登録番号（8~10桁）、信頼度スコア（0.0-1.0）、生テキスト
+- **出力**: 防犯登録番号（基本は8~10桁。大阪府シール形式は末尾6桁を特例抽出）、信頼度スコア（0.0-1.0）、生テキスト
 - **対応フォーマット**: JPEG, PNG, BMP, TIFF
 - **精度**: Azure Form Recognizer依存（一般的に95%以上）
 

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -1,12 +1,22 @@
 import Fastify from 'fastify';
 import fastifyJwt from '@fastify/jwt';
+import type { PrismaClient } from '@prisma/client';
 import authRoutes from './routes/auth';
 import bikeRoutes from './routes/bikes';
 import ownerRoutes from './routes/owner';
+import { sendError, UnauthorizedError } from './lib/errors';
+import { AuthService } from './services/authService';
+import type { OCRService } from './services/ocrService';
 
 import prismaPlugin from './plugins/prisma';
 
-export function buildServer({ prisma }: { prisma?: any } = {}) {
+type BuildServerOptions = {
+  prisma?: PrismaClient;
+  ocrService?: OCRService;
+  now?: () => Date;
+};
+
+export function buildServer({ prisma, ocrService, now }: BuildServerOptions = {}) {
   const server = Fastify({ logger: false });
 
   server.register(fastifyJwt, {
@@ -16,7 +26,7 @@ export function buildServer({ prisma }: { prisma?: any } = {}) {
   if (prisma) {
     server.decorate('prisma', prisma);
   } else {
-    server.register(prismaPlugin);
+    prismaPlugin(server);
   }
 
   server.get('/', async () => ({ ok: true, version: '0.1.0' }));
@@ -24,22 +34,24 @@ export function buildServer({ prisma }: { prisma?: any } = {}) {
   // Protected route example
   server.get('/users/me', async (request, reply) => {
     try {
-      await (request as any).jwtVerify();
-    } catch (err) {
-      return reply.status(401).send({ error: 'Unauthorized' });
+      await request.jwtVerify();
+      const tokenPayload = request.user as { sub?: string | number } | undefined;
+      const userId = tokenPayload?.sub ? String(tokenPayload.sub) : '';
+      const authService = new AuthService(server.prisma as any);
+      const user = await authService.getUserProfile(userId);
+      return reply.send(user);
+    } catch (error) {
+      const normalizedError =
+        error instanceof Error && error.message.toLowerCase().includes('authorization')
+          ? new UnauthorizedError('Unauthorized')
+          : error;
+      return sendError(reply, server.log, normalizedError);
     }
-    const userId = (request as any).user.sub;
-    const user = await (server as any).prisma.user.findUnique({
-      where: { id: userId },
-      select: { id: true, name: true, email: true, role: true },
-    });
-    if (!user) return reply.status(404).send({ error: 'User not found' });
-    return reply.send(user);
   });
 
   server.register(authRoutes, { prefix: '/auth' });
-  server.register(bikeRoutes, { prefix: '/bikes' });
-  server.register(ownerRoutes, { prefix: '/owner' });
+  server.register(bikeRoutes({ ocrService }), { prefix: '/bikes' });
+  server.register(ownerRoutes({ now }), { prefix: '/owner' });
 
   return server;
 }

--- a/backend/src/lib/errors.ts
+++ b/backend/src/lib/errors.ts
@@ -1,0 +1,48 @@
+import type { FastifyBaseLogger, FastifyReply } from 'fastify';
+
+export class AppError extends Error {
+  constructor(
+    message: string,
+    public readonly statusCode: number,
+    public readonly details?: Record<string, unknown>
+  ) {
+    super(message);
+    this.name = 'AppError';
+  }
+}
+
+export class BadRequestError extends AppError {
+  constructor(message: string, details?: Record<string, unknown>) {
+    super(message, 400, details);
+  }
+}
+
+export class UnauthorizedError extends AppError {
+  constructor(message = 'Unauthorized') {
+    super(message, 401);
+  }
+}
+
+export class NotFoundError extends AppError {
+  constructor(message: string, details?: Record<string, unknown>) {
+    super(message, 404, details);
+  }
+}
+
+export class ConflictError extends AppError {
+  constructor(message: string, details?: Record<string, unknown>) {
+    super(message, 409, details);
+  }
+}
+
+export function sendError(reply: FastifyReply, logger: FastifyBaseLogger, error: unknown) {
+  if (error instanceof AppError) {
+    return reply.status(error.statusCode).send({
+      error: error.message,
+      ...(error.details ?? {}),
+    });
+  }
+
+  logger.error({ err: error }, 'Unhandled route error');
+  return reply.status(500).send({ error: 'Internal Server Error' });
+}

--- a/backend/src/plugins/prisma.ts
+++ b/backend/src/plugins/prisma.ts
@@ -1,4 +1,5 @@
 import { PrismaClient } from '@prisma/client';
+import type { FastifyInstance } from 'fastify';
 
 declare module 'fastify' {
   interface FastifyInstance {
@@ -6,9 +7,7 @@ declare module 'fastify' {
   }
 }
 
-const prisma = new PrismaClient();
-
-export default async function (fastify: any, opts: any) {
+export default function registerPrisma(fastify: FastifyInstance, prisma = new PrismaClient()) {
   fastify.decorate('prisma', prisma);
   fastify.addHook('onClose', async () => {
     await prisma.$disconnect();

--- a/backend/src/routes/auth.ts
+++ b/backend/src/routes/auth.ts
@@ -1,65 +1,43 @@
-import { FastifyInstance } from 'fastify';
-import bcrypt from 'bcryptjs';
+import type { FastifyPluginAsync } from 'fastify';
+import { sendError } from '../lib/errors';
+import { AuthService } from '../services/authService';
 
-export default async function (fastify: FastifyInstance) {
-  fastify.post('/register', async (request, reply) => {
-    const body = request.body as any;
-    if (!body?.email || !body?.password) {
-      return reply.status(400).send({ error: 'email and password required' });
+type RegisterBody = {
+  name?: string | null;
+  email?: string;
+  password?: string;
+};
+
+type LoginBody = {
+  email?: string;
+  password?: string;
+};
+
+const authRoutes: FastifyPluginAsync = async (fastify) => {
+  const authService = new AuthService(fastify.prisma as any);
+
+  fastify.post<{ Body: RegisterBody }>('/register', async (request, reply) => {
+    try {
+      const user = await authService.register(request.body ?? {});
+      return reply.status(201).send(user);
+    } catch (error) {
+      return sendError(reply, fastify.log, error);
     }
-
-    // check existing
-    const existing = await (fastify as any).prisma.user.findUnique({
-      where: { email: body.email },
-    });
-    if (existing) {
-      return reply.status(409).send({ error: 'email already in use' });
-    }
-
-    const hashed = await bcrypt.hash(body.password, 10);
-    fastify.log.info({ email: body.email }, 'register: creating user');
-    const user = await (fastify as any).prisma.user.create({
-      data: {
-        name: body.name || null,
-        email: body.email,
-        password: hashed,
-      },
-      select: {
-        id: true,
-        name: true,
-        email: true,
-        role: true,
-        createdAt: true,
-      },
-    });
-    fastify.log.info({ id: user.id }, 'register: created user');
-
-    return reply.status(201).send(user);
   });
 
-  fastify.post('/login', async (request, reply) => {
-    const body = request.body as any;
-    if (!body?.email || !body?.password) {
-      return reply.status(400).send({ error: 'email and password required' });
+  fastify.post<{ Body: LoginBody }>('/login', async (request, reply) => {
+    try {
+      const user = await authService.login(request.body ?? {});
+      const token = fastify.jwt.sign({
+        sub: user.id,
+        email: user.email,
+        role: user.role,
+      });
+      return reply.send({ accessToken: token, tokenType: 'Bearer' });
+    } catch (error) {
+      return sendError(reply, fastify.log, error);
     }
-
-    const user = await (fastify as any).prisma.user.findUnique({
-      where: { email: body.email },
-    });
-    if (!user) {
-      return reply.status(401).send({ error: 'invalid credentials' });
-    }
-
-    const valid = await bcrypt.compare(body.password, (user as any).password);
-    if (!valid) {
-      return reply.status(401).send({ error: 'invalid credentials' });
-    }
-
-    const token = (fastify as any).jwt.sign({
-      sub: user.id,
-      email: user.email,
-      role: user.role,
-    });
-    return reply.send({ accessToken: token, tokenType: 'Bearer' });
   });
-}
+};
+
+export default authRoutes;

--- a/backend/src/routes/bikes.ts
+++ b/backend/src/routes/bikes.ts
@@ -1,115 +1,109 @@
-import { FastifyInstance } from 'fastify';
-import { getOCRService } from '../services/ocrService';
+import type { FastifyPluginAsync } from 'fastify';
+import { BadRequestError, sendError } from '../lib/errors';
+import { BikeService } from '../services/bikeService';
+import { getOCRService, type OCRService } from '../services/ocrService';
 
-export default async function (fastify: FastifyInstance) {
-  // List bikes
-  fastify.get('/', async (request, reply) => {
-    const bikes = await (fastify as any).prisma.bike.findMany();
-    return reply.send(bikes);
-  });
+type BikeParams = {
+  id: string;
+};
 
-  // Create bike
-  fastify.post('/', async (request, reply) => {
-    const body = request.body as any;
-    if (!body?.serialNumber) {
-      return reply.status(400).send({ error: 'serialNumber required' });
-    }
+type CreateBikeBody = {
+  serialNumber?: string;
+  location?: string | null;
+  status?: string;
+};
 
-    const existing = await (fastify as any).prisma.bike.findUnique({
-      where: { serialNumber: body.serialNumber },
-    });
-    if (existing)
-      return reply.status(409).send({ error: 'serialNumber already exists' });
+type UpdateBikeBody = {
+  location?: string | null;
+  status?: string;
+};
 
-    const bike = await (fastify as any).prisma.bike.create({
-      data: {
-        serialNumber: body.serialNumber,
-        location: body.location || null,
-        status: body.status || 'available',
-      },
-    });
+type OCRRequestBody = {
+  filePath?: string;
+};
 
-    return reply.status(201).send(bike);
-  });
+export default function createBikeRoutes(options: { ocrService?: OCRService } = {}): FastifyPluginAsync {
+  return async function bikeRoutes(fastify) {
+    const bikeService = new BikeService(fastify.prisma as any);
+    const resolveOCRService = () => options.ocrService ?? getOCRService();
 
-  // Get bike
-  fastify.get('/:id', async (request, reply) => {
-    const params = request.params as any;
-    const bike = await (fastify as any).prisma.bike.findUnique({
-      where: { id: params.id },
-    });
-    if (!bike) return reply.status(404).send({ error: 'not found' });
-    return reply.send(bike);
-  });
-
-  // Update bike
-  fastify.put('/:id', async (request, reply) => {
-    const params = request.params as any;
-    const body = request.body as any;
-    try {
-      const bike = await (fastify as any).prisma.bike.update({
-        where: { id: params.id },
-        data: {
-          location: body.location,
-          status: body.status,
-        },
-      });
-      return reply.send(bike);
-    } catch (err) {
-      return reply.status(404).send({ error: 'not found' });
-    }
-  });
-
-  // Delete bike
-  fastify.delete('/:id', async (request, reply) => {
-    const params = request.params as any;
-    try {
-      await (fastify as any).prisma.bike.delete({ where: { id: params.id } });
-      return reply.status(204).send();
-    } catch (err) {
-      return reply.status(404).send({ error: 'not found' });
-    }
-  });
-
-  // OCR: Recognize registration number from image
-  fastify.post('/ocr/recognize', async (request, reply) => {
-    const body = request.body as any;
-    if (!body?.filePath) {
-      return reply.status(400).send({ 
-        error: 'filePath required',
-        message: 'FTPから取得した画像ファイルのパスを指定してください'
-      });
-    }
-
-    try {
-      const ocrService = getOCRService();
-      const result = await ocrService.recognizeRegistrationNumber(body.filePath);
-      
-      if (!result.success) {
-        return reply.status(400).send({ 
-          error: result.error,
-          result: {
-            registrationNumber: null,
-            confidence: 0,
-            rawText: ''
-          }
-        });
+    fastify.get('/', async (_request, reply) => {
+      try {
+        const bikes = await bikeService.listBikes();
+        return reply.send(bikes);
+      } catch (error) {
+        return sendError(reply, fastify.log, error);
       }
+    });
 
-      return reply.status(200).send({
-        success: true,
-        result: {
-          registrationNumber: result.registrationNumber,
-          confidence: result.confidence,
-          rawText: result.rawText
+    fastify.post<{ Body: CreateBikeBody }>('/', async (request, reply) => {
+      try {
+        const bike = await bikeService.createBike(request.body ?? {});
+        return reply.status(201).send(bike);
+      } catch (error) {
+        return sendError(reply, fastify.log, error);
+      }
+    });
+
+    fastify.get<{ Params: BikeParams }>('/:id', async (request, reply) => {
+      try {
+        const bike = await bikeService.getBike(request.params.id);
+        return reply.send(bike);
+      } catch (error) {
+        return sendError(reply, fastify.log, error);
+      }
+    });
+
+    fastify.put<{ Params: BikeParams; Body: UpdateBikeBody }>('/:id', async (request, reply) => {
+      try {
+        const bike = await bikeService.updateBike(request.params.id, request.body ?? {});
+        return reply.send(bike);
+      } catch (error) {
+        return sendError(reply, fastify.log, error);
+      }
+    });
+
+    fastify.delete<{ Params: BikeParams }>('/:id', async (request, reply) => {
+      try {
+        await bikeService.deleteBike(request.params.id);
+        return reply.status(204).send();
+      } catch (error) {
+        return sendError(reply, fastify.log, error);
+      }
+    });
+
+    fastify.post<{ Body: OCRRequestBody }>('/ocr/recognize', async (request, reply) => {
+      try {
+        if (!request.body?.filePath) {
+          throw new BadRequestError('filePath required', {
+            message: 'FTPから取得した画像ファイルのパスを指定してください',
+          });
         }
-      });
-    } catch (err) {
-      const errorMessage = err instanceof Error ? err.message : 'Unknown error occurred';
-      return reply.status(500).send({ 
-        error: 'OCR処理中にエラーが発生しました',
-        details: errorMessage
-      });
-    }
-  });
+
+        const result = await resolveOCRService().recognizeRegistrationNumber(request.body.filePath);
+
+        if (!result.success) {
+          return reply.status(400).send({
+            error: result.error,
+            result: {
+              registrationNumber: null,
+              confidence: 0,
+              rawText: '',
+            },
+          });
+        }
+
+        return reply.status(200).send({
+          success: true,
+          result: {
+            registrationNumber: result.registrationNumber,
+            confidence: result.confidence,
+            rawText: result.rawText,
+          },
+        });
+      } catch (error) {
+        return sendError(reply, fastify.log, error);
+      }
+    });
+  };
 }

--- a/backend/src/routes/owner.ts
+++ b/backend/src/routes/owner.ts
@@ -1,188 +1,88 @@
-import { FastifyInstance } from 'fastify';
+import type { FastifyPluginAsync } from 'fastify';
+import { sendError } from '../lib/errors';
 import { CouponService } from '../services/couponService';
+import { OwnerUnlockService } from '../services/ownerUnlockService';
 
-export default async function (fastify: FastifyInstance) {
-  const couponService = new CouponService((fastify as any).prisma);
+type MarkerParams = {
+  code: string;
+};
 
-  // マーカーIDからクーポン一覧を取得
-  fastify.get('/markers/:code/coupons', async (request, reply) => {
-    const params = request.params as any;
-    const { code } = params;
+type CouponParams = {
+  id: string;
+};
 
-    try {
-      // マーカーを検索
-      const marker = await (fastify as any).prisma.marker.findUnique({
-        where: { code },
-      });
+type TemporaryUnlockBody = {
+  notes?: string;
+};
 
-      if (!marker) {
-        return reply.status(404).send({ error: 'Marker not found' });
+type FinalUnlockBody = {
+  scannedCode?: string;
+  ownerEmail?: string;
+};
+
+export default function createOwnerRoutes(options: { now?: () => Date } = {}): FastifyPluginAsync {
+  return async function ownerRoutes(fastify) {
+    const couponService = new CouponService(fastify.prisma as any);
+    const ownerUnlockService = new OwnerUnlockService(
+      fastify.prisma as any,
+      couponService,
+      options.now
+    );
+
+    fastify.get<{ Params: MarkerParams }>('/markers/:code/coupons', async (request, reply) => {
+      try {
+        const response = await ownerUnlockService.getCouponsByMarkerCode(request.params.code);
+        return reply.send(response);
+      } catch (error) {
+        return sendError(reply, fastify.log, error);
       }
+    });
 
-      // クーポン一覧を取得
-      const coupons = await couponService.getCouponsByMarker(marker.id);
+    fastify.post<{ Params: MarkerParams; Body: FinalUnlockBody }>(
+      '/markers/:code/unlock-final',
+      async (request, reply) => {
+        try {
+          const response = await ownerUnlockService.finalizeUnlock(request.params.code, request.body ?? {});
+          return reply.send(response);
+        } catch (error) {
+          return sendError(reply, fastify.log, error);
+        }
+      }
+    );
 
-      return reply.send({
-        markerId: marker.id,
-        code: marker.code,
-        coupons,
-      });
-    } catch (error) {
-      console.error('クーポン取得エラー:', error);
-      return reply.status(500).send({ error: 'Failed to fetch coupons' });
-    }
-  });
+    fastify.post<{ Params: MarkerParams; Body: TemporaryUnlockBody }>(
+      '/markers/:code/unlock-temp',
+      async (request, reply) => {
+        try {
+          const response = await ownerUnlockService.createTemporaryUnlock(
+            request.params.code,
+            request.body?.notes
+          );
+          return reply.send(response);
+        } catch (error) {
+          return sendError(reply, fastify.log, error);
+        }
+      }
+    );
 
-  // 本解除時のクーポン発行（内部API）
-  fastify.post('/markers/:code/unlock-final', async (request, reply) => {
-    const params = request.params as any;
-    const body = request.body as any;
-    const { code } = params;
-    const { ownerEmail } = body;
+    fastify.post<{ Params: CouponParams }>('/coupons/:id/use', async (request, reply) => {
+      try {
+        const success = await ownerUnlockService.useCoupon(request.params.id);
 
-    try {
-      // マーカーを検索または作成
-      let marker = await (fastify as any).prisma.marker.findUnique({
-        where: { code },
-      });
+        if (!success) {
+          return reply.status(400).send({
+            error: 'Coupon cannot be used',
+            message: 'クーポンは既に使用済みまたは期限切れです',
+          });
+        }
 
-      if (!marker) {
-        marker = await (fastify as any).prisma.marker.create({
-          data: { code },
+        return reply.send({
+          success: true,
+          message: 'クーポンを使用しました',
         });
+      } catch (error) {
+        return sendError(reply, fastify.log, error);
       }
-
-      // 最新の宣言を取得
-      const declaration = await (fastify as any).prisma.declaration.findFirst({
-        where: {
-          markerId: marker.id,
-          status: 'temporary',
-        },
-        orderBy: { declaredAt: 'desc' },
-      });
-
-      if (!declaration) {
-        return reply.status(400).send({ error: 'No temporary declaration found' });
-      }
-
-      // 本解除可能時刻チェック
-      const now = new Date();
-      if (now < declaration.eligibleFinalAt) {
-        return reply.status(400).send({
-          error: 'eligibleFinalAt has not arrived',
-          eligibleFinalAt: declaration.eligibleFinalAt,
-          currentTime: now,
-        });
-      }
-
-      // 本解除処理
-      await (fastify as any).prisma.declaration.update({
-        where: { id: declaration.id },
-        data: {
-          status: 'resolved',
-          finalizedAt: now,
-        },
-      });
-
-      // クーポン発行
-      const coupon = await couponService.issueCouponForFinalUnlock(
-        marker.id,
-        ownerEmail
-      );
-
-      return reply.send({
-        finalizedAt: now,
-        status: 'resolved',
-        coupon: coupon
-          ? {
-              id: coupon.id,
-              name: coupon.name,
-              description: coupon.description,
-              shopName: coupon.shopName,
-              discount: coupon.discount,
-              discountType: coupon.discountType,
-              expiresAt: coupon.expiresAt,
-            }
-          : null,
-        message: coupon
-          ? 'クーポンを獲得しました！商店街でご利用ください。'
-          : '本解除が完了しました',
-      });
-    } catch (error) {
-      console.error('本解除エラー:', error);
-      return reply.status(500).send({ error: 'Failed to finalize unlock' });
-    }
-  });
-
-  // 仮解除エンドポイント
-  fastify.post('/markers/:code/unlock-temp', async (request, reply) => {
-    const params = request.params as any;
-    const body = request.body as any;
-    const { code } = params;
-    const { notes } = body;
-
-    try {
-      // マーカーを検索または作成
-      let marker = await (fastify as any).prisma.marker.findUnique({
-        where: { code },
-      });
-
-      if (!marker) {
-        marker = await (fastify as any).prisma.marker.create({
-          data: { code },
-        });
-      }
-
-      const declaredAt = new Date();
-      const eligibleFinalAt = new Date(declaredAt.getTime() + 15 * 60 * 1000); // 15分後
-      const expiresAt = new Date(declaredAt.getTime() + 24 * 60 * 60 * 1000); // 24時間後
-
-      // 宣言を作成
-      const declaration = await (fastify as any).prisma.declaration.create({
-        data: {
-          markerId: marker.id,
-          declaredAt,
-          eligibleFinalAt,
-          expiresAt,
-          status: 'temporary',
-          notes,
-        },
-      });
-
-      return reply.send({
-        declaredAt: declaration.declaredAt,
-        eligibleFinalAt: declaration.eligibleFinalAt,
-        expiresAt: declaration.expiresAt,
-        status: declaration.status,
-      });
-    } catch (error) {
-      console.error('仮解除エラー:', error);
-      return reply.status(500).send({ error: 'Failed to create temporary unlock' });
-    }
-  });
-
-  // クーポン使用
-  fastify.post('/coupons/:id/use', async (request, reply) => {
-    const params = request.params as any;
-    const { id } = params;
-
-    try {
-      const success = await couponService.useCoupon(id);
-
-      if (!success) {
-        return reply.status(400).send({
-          error: 'Coupon cannot be used',
-          message: 'クーポンは既に使用済みまたは期限切れです',
-        });
-      }
-
-      return reply.send({
-        success: true,
-        message: 'クーポンを使用しました',
-      });
-    } catch (error) {
-      console.error('クーポン使用エラー:', error);
-      return reply.status(500).send({ error: 'Failed to use coupon' });
-    }
-  });
+    });
+  };
 }

--- a/backend/src/services/authService.ts
+++ b/backend/src/services/authService.ts
@@ -1,0 +1,115 @@
+import bcrypt from 'bcryptjs';
+import { BadRequestError, ConflictError, NotFoundError, UnauthorizedError } from '../lib/errors';
+
+type RegisterInput = {
+  name?: string | null;
+  email?: string;
+  password?: string;
+};
+
+type LoginInput = {
+  email?: string;
+  password?: string;
+};
+
+type PublicUser = {
+  id: string;
+  name: string | null;
+  email: string;
+  role: string;
+  createdAt: Date;
+};
+
+type UserRecord = PublicUser & {
+  password: string;
+};
+
+type AuthPrisma = {
+  user: {
+    findUnique(args: {
+      where: { email?: string; id?: string };
+      select?: Record<string, boolean>;
+    }): Promise<UserRecord | PublicUser | null>;
+    create(args: {
+      data: { name: string | null; email: string; password: string };
+      select?: Record<string, boolean>;
+    }): Promise<PublicUser>;
+  };
+};
+
+export class AuthService {
+  constructor(private readonly prisma: AuthPrisma) {}
+
+  async register(input: RegisterInput): Promise<PublicUser> {
+    if (!input.email || !input.password) {
+      throw new BadRequestError('email and password required');
+    }
+
+    const existing = await this.prisma.user.findUnique({
+      where: { email: input.email },
+    });
+    if (existing) {
+      throw new ConflictError('email already in use');
+    }
+
+    const hashedPassword = await bcrypt.hash(input.password, 10);
+    return this.prisma.user.create({
+      data: {
+        name: input.name ?? null,
+        email: input.email,
+        password: hashedPassword,
+      },
+      select: {
+        id: true,
+        name: true,
+        email: true,
+        role: true,
+        createdAt: true,
+      },
+    });
+  }
+
+  async login(input: LoginInput): Promise<{ id: string; email: string; role: string }> {
+    if (!input.email || !input.password) {
+      throw new BadRequestError('email and password required');
+    }
+
+    const user = (await this.prisma.user.findUnique({
+      where: { email: input.email },
+    })) as UserRecord | null;
+
+    if (!user) {
+      throw new UnauthorizedError('invalid credentials');
+    }
+
+    const validPassword = await bcrypt.compare(input.password, user.password);
+    if (!validPassword) {
+      throw new UnauthorizedError('invalid credentials');
+    }
+
+    return {
+      id: user.id,
+      email: user.email,
+      role: user.role,
+    };
+  }
+
+  async getUserProfile(userId: string): Promise<PublicUser> {
+    const user = await this.prisma.user.findUnique({
+      where: { id: userId },
+      select: {
+        id: true,
+        name: true,
+        email: true,
+        role: true,
+        createdAt: true,
+      },
+    });
+
+    if (!user) {
+      throw new NotFoundError('User not found');
+    }
+
+    return user as PublicUser;
+  }
+}

--- a/backend/src/services/bikeService.ts
+++ b/backend/src/services/bikeService.ts
@@ -1,0 +1,82 @@
+import { BadRequestError, ConflictError, NotFoundError } from '../lib/errors';
+
+type BikeRecord = {
+  id: string;
+  serialNumber: string;
+  status: string;
+  location: string | null;
+  createdAt: Date;
+  updatedAt: Date;
+};
+
+type BikePrisma = {
+  bike: {
+    findMany(): Promise<BikeRecord[]>;
+    findUnique(args: { where: { id?: string; serialNumber?: string } }): Promise<BikeRecord | null>;
+    create(args: {
+      data: { serialNumber: string; location?: string | null; status?: string };
+    }): Promise<BikeRecord>;
+    update(args: {
+      where: { id: string };
+      data: { location?: string | null; status?: string };
+    }): Promise<BikeRecord>;
+    delete(args: { where: { id: string } }): Promise<BikeRecord>;
+  };
+};
+
+export class BikeService {
+  constructor(private readonly prisma: BikePrisma) {}
+
+  async listBikes() {
+    return this.prisma.bike.findMany();
+  }
+
+  async createBike(input: { serialNumber?: string; location?: string | null; status?: string }) {
+    if (!input.serialNumber) {
+      throw new BadRequestError('serialNumber required');
+    }
+
+    const existing = await this.prisma.bike.findUnique({
+      where: { serialNumber: input.serialNumber },
+    });
+    if (existing) {
+      throw new ConflictError('serialNumber already exists');
+    }
+
+    return this.prisma.bike.create({
+      data: {
+        serialNumber: input.serialNumber,
+        location: input.location ?? null,
+        status: input.status ?? 'available',
+      },
+    });
+  }
+
+  async getBike(id: string) {
+    const bike = await this.prisma.bike.findUnique({
+      where: { id },
+    });
+    if (!bike) {
+      throw new NotFoundError('not found');
+    }
+    return bike;
+  }
+
+  async updateBike(id: string, input: { location?: string | null; status?: string }) {
+    await this.getBike(id);
+    return this.prisma.bike.update({
+      where: { id },
+      data: {
+        location: input.location,
+        status: input.status,
+      },
+    });
+  }
+
+  async deleteBike(id: string) {
+    await this.getBike(id);
+    await this.prisma.bike.delete({
+      where: { id },
+    });
+  }
+}

--- a/backend/src/services/couponService.ts
+++ b/backend/src/services/couponService.ts
@@ -1,5 +1,3 @@
-import { PrismaClient } from '@prisma/client';
-
 export interface CouponData {
   id: string;
   name: string;
@@ -12,11 +10,77 @@ export interface CouponData {
   issuedAt: Date;
 }
 
+type CouponRecord = {
+  id: string;
+  name: string;
+  description: string;
+  shopName: string;
+  discount: number;
+  discountType: string;
+  validDays: number;
+  isActive: boolean;
+  createdAt: Date;
+};
+
+type CouponIssuanceRecord = {
+  id: string;
+  couponId: string;
+  markerId: string | null;
+  ownerEmail: string | null;
+  expiresAt: Date;
+  issuedAt: Date;
+  usedAt: Date | null;
+  status: string;
+};
+
+type CouponPrisma = {
+  coupon: {
+    findFirst(args: {
+      where: { isActive: boolean };
+      orderBy: { createdAt: 'asc' | 'desc' };
+    }): Promise<CouponRecord | null>;
+    count(): Promise<number>;
+    createMany(args: {
+      data: Array<{
+        name: string;
+        description: string;
+        shopName: string;
+        discount: number;
+        discountType: string;
+        validDays: number;
+        isActive: boolean;
+      }>;
+    }): Promise<{ count: number }>;
+  };
+  couponIssuance: {
+    create(args: {
+      data: {
+        couponId: string;
+        markerId: string;
+        ownerEmail?: string | null;
+        expiresAt: Date;
+        status: string;
+      };
+      include: { coupon: boolean };
+    }): Promise<CouponIssuanceRecord & { coupon: CouponRecord }>;
+    findMany(args: {
+      where: { markerId: string; status: { in: string[] } };
+      include: { coupon: boolean };
+      orderBy: { issuedAt: 'asc' | 'desc' };
+    }): Promise<Array<CouponIssuanceRecord & { coupon: CouponRecord }>>;
+    findUnique(args: { where: { id: string } }): Promise<CouponIssuanceRecord | null>;
+    update(args: {
+      where: { id: string };
+      data: { status: string; usedAt?: Date | null };
+    }): Promise<CouponIssuanceRecord>;
+  };
+};
+
 /**
  * クーポンサービス - クーポンの発行・取得・使用を管理
  */
 export class CouponService {
-  constructor(private prisma: PrismaClient) {}
+  constructor(private readonly prisma: CouponPrisma) {}
 
   /**
    * 本解除時にクーポンを自動発行
@@ -26,57 +90,49 @@ export class CouponService {
    */
   async issueCouponForFinalUnlock(
     markerId: string,
-    ownerEmail?: string
+    ownerEmail?: string | null,
+    issuedAt: Date = new Date()
   ): Promise<CouponData | null> {
-    try {
-      // アクティブなクーポンを1つ取得（商店街のクーポン）
-      const availableCoupon = await this.prisma.coupon.findFirst({
-        where: {
-          isActive: true,
-        },
-        orderBy: {
-          createdAt: 'desc',
-        },
-      });
+    const availableCoupon = await this.prisma.coupon.findFirst({
+      where: {
+        isActive: true,
+      },
+      orderBy: {
+        createdAt: 'desc',
+      },
+    });
 
-      if (!availableCoupon) {
-        console.warn('利用可能なクーポンが見つかりません');
-        return null;
-      }
-
-      // クーポン有効期限を計算
-      const expiresAt = new Date();
-      expiresAt.setDate(expiresAt.getDate() + availableCoupon.validDays);
-
-      // クーポンを発行
-      const issuance = await this.prisma.couponIssuance.create({
-        data: {
-          couponId: availableCoupon.id,
-          markerId,
-          ownerEmail,
-          expiresAt,
-          status: 'active',
-        },
-        include: {
-          coupon: true,
-        },
-      });
-
-      return {
-        id: issuance.id,
-        name: issuance.coupon.name,
-        description: issuance.coupon.description,
-        shopName: issuance.coupon.shopName,
-        discount: issuance.coupon.discount,
-        discountType: issuance.coupon.discountType,
-        expiresAt: issuance.expiresAt,
-        status: issuance.status,
-        issuedAt: issuance.issuedAt,
-      };
-    } catch (error) {
-      console.error('クーポン発行エラー:', error);
+    if (!availableCoupon) {
       return null;
     }
+
+    const expiresAt = new Date(issuedAt);
+    expiresAt.setDate(expiresAt.getDate() + availableCoupon.validDays);
+
+    const issuance = await this.prisma.couponIssuance.create({
+      data: {
+        couponId: availableCoupon.id,
+        markerId,
+        ownerEmail,
+        expiresAt,
+        status: 'active',
+      },
+      include: {
+        coupon: true,
+      },
+    });
+
+    return {
+      id: issuance.id,
+      name: issuance.coupon.name,
+      description: issuance.coupon.description,
+      shopName: issuance.coupon.shopName,
+      discount: issuance.coupon.discount,
+      discountType: issuance.coupon.discountType,
+      expiresAt: issuance.expiresAt,
+      status: issuance.status,
+      issuedAt: issuance.issuedAt,
+    };
   }
 
   /**
@@ -118,38 +174,32 @@ export class CouponService {
    * @param couponIssuanceId クーポン発行ID
    * @returns 成功したかどうか
    */
-  async useCoupon(couponIssuanceId: string): Promise<boolean> {
-    try {
-      const issuance = await this.prisma.couponIssuance.findUnique({
-        where: { id: couponIssuanceId },
-      });
+  async useCoupon(couponIssuanceId: string, now: Date = new Date()): Promise<boolean> {
+    const issuance = await this.prisma.couponIssuance.findUnique({
+      where: { id: couponIssuanceId },
+    });
 
-      if (!issuance || issuance.status !== 'active') {
-        return false;
-      }
-
-      // 有効期限チェック
-      if (new Date() > issuance.expiresAt) {
-        await this.prisma.couponIssuance.update({
-          where: { id: couponIssuanceId },
-          data: { status: 'expired' },
-        });
-        return false;
-      }
-
-      await this.prisma.couponIssuance.update({
-        where: { id: couponIssuanceId },
-        data: {
-          status: 'used',
-          usedAt: new Date(),
-        },
-      });
-
-      return true;
-    } catch (error) {
-      console.error('クーポン使用エラー:', error);
+    if (!issuance || issuance.status !== 'active') {
       return false;
     }
+
+    if (now > issuance.expiresAt) {
+      await this.prisma.couponIssuance.update({
+        where: { id: couponIssuanceId },
+        data: { status: 'expired' },
+      });
+      return false;
+    }
+
+    await this.prisma.couponIssuance.update({
+      where: { id: couponIssuanceId },
+      data: {
+        status: 'used',
+        usedAt: now,
+      },
+    });
+
+    return true;
   }
 
   /**

--- a/backend/src/services/ocrService.ts
+++ b/backend/src/services/ocrService.ts
@@ -2,7 +2,7 @@ import { DocumentAnalysisClient, AzureKeyCredential } from '@azure/ai-form-recog
 import { readFileSync } from 'fs';
 import { resolve } from 'path';
 
-interface OCRResult {
+export interface OCRResult {
   registrationNumber: string | null;
   confidence: number;
   rawText: string;
@@ -10,41 +10,125 @@ interface OCRResult {
   error?: string;
 }
 
-/**
- * OCRサービス - 防犯登録番号をAzure Form Recognizerで認識
- */
-export class OCRService {
-  private client: DocumentAnalysisClient;
+export type OCRLine = {
+  confidence?: number;
+  words?: Array<{ confidence?: number }>;
+};
+
+export type OCRPage = {
+  confidence?: number;
+  lines?: OCRLine[];
+};
+
+type OCRAnalysis = {
+  content: string;
+  pages?: OCRPage[];
+};
+
+export interface DocumentAnalyzer {
+  analyzeDocument(buffer: Buffer): Promise<OCRAnalysis>;
+}
+
+class AzureDocumentAnalyzer implements DocumentAnalyzer {
+  private readonly client: DocumentAnalysisClient;
 
   constructor(endpoint: string, apiKey: string) {
     this.client = new DocumentAnalysisClient(endpoint, new AzureKeyCredential(apiKey));
   }
 
-  /**
-   * 画像ファイルから防犯登録番号を抽出
-   * @param imagePath - ローカルファイルパス（FTPから取得したファイルなど）
-   * @returns OCR結果（登録番号、信頼度スコア、生テキスト）
-   */
+  async analyzeDocument(buffer: Buffer): Promise<OCRAnalysis> {
+    const poller = await this.client.beginAnalyzeDocument('prebuilt-read', buffer);
+    return poller.pollUntilDone();
+  }
+}
+
+export function extractRegistrationNumber(text: string): string | null {
+  const prioritizedMatch = text.match(/防犯登録[\s\S]{0,50}?(\d{8,10})\b/u);
+  if (prioritizedMatch?.[1]) {
+    return prioritizedMatch[1];
+  }
+
+  const directMatches = Array.from(text.matchAll(/\b\d{8,10}\b/g)).map((match) => ({
+    value: match[0],
+    index: match.index ?? 0,
+  }));
+
+  if (directMatches.length > 0) {
+    const contextualMatch = directMatches.find(({ index }) => {
+      const before = text.slice(Math.max(0, index - 50), index);
+      const after = text.slice(index, Math.min(text.length, index + 50));
+      return (
+        before.includes('防犯登録') ||
+        before.includes('大阪府警察') ||
+        after.includes('大阪府警察')
+      );
+    });
+
+    return contextualMatch?.value ?? directMatches[0].value;
+  }
+
+  const osakaPattern = text.match(/a(\d{11,12})a/gi);
+  if (osakaPattern?.[0]) {
+    const numericPart = osakaPattern[0].match(/\d+/)?.[0];
+    if (numericPart && numericPart.length >= 6) {
+      return numericPart.slice(-6);
+    }
+  }
+
+  return null;
+}
+
+export function calculateConfidence(pages: OCRPage[]): number {
+  if (pages.length === 0) {
+    return 0;
+  }
+
+  let totalConfidence = 0;
+  let count = 0;
+
+  for (const page of pages) {
+    if (typeof page.confidence === 'number') {
+      totalConfidence += page.confidence;
+      count += 1;
+    }
+
+    for (const line of page.lines ?? []) {
+      if (typeof line.confidence === 'number') {
+        totalConfidence += line.confidence;
+        count += 1;
+      }
+
+      for (const word of line.words ?? []) {
+        if (typeof word.confidence === 'number') {
+          totalConfidence += word.confidence;
+          count += 1;
+        }
+      }
+    }
+  }
+
+  return count > 0 ? totalConfidence / count : 0.95;
+}
+
+export class OCRService {
+  constructor(
+    private readonly analyzer: DocumentAnalyzer,
+    private readonly readBuffer: (imagePath: string) => Buffer = (imagePath) =>
+      readFileSync(resolve(imagePath))
+  ) {}
+
   async recognizeRegistrationNumber(imagePath: string): Promise<OCRResult> {
     try {
-      // ローカルファイルを読み込み
-      const absolutePath = resolve(imagePath);
-      const imageBuffer = readFileSync(absolutePath);
-
-      // Azure Form Recognizerで文書分析
-      const poller = await this.client.beginAnalyzeDocument('prebuilt-read', imageBuffer);
-
-      const result = await poller.pollUntilDone();
-
-      // 抽出テキストから防犯登録番号を抽出
-      const fullText = result.content;
-      const registrationNumber = this.extractRegistrationNumber(fullText);
-      const confidence = this.calculateConfidence(result.pages || []);
+      const imageBuffer = this.readBuffer(imagePath);
+      const result = await this.analyzer.analyzeDocument(imageBuffer);
+      const rawText = result.content ?? '';
+      const registrationNumber = extractRegistrationNumber(rawText);
+      const confidence = calculateConfidence(result.pages ?? []);
 
       return {
         registrationNumber,
         confidence,
-        rawText: fullText,
+        rawText,
         success: registrationNumber !== null,
       };
     } catch (error) {
@@ -58,104 +142,8 @@ export class OCRService {
       };
     }
   }
-
-  /**
-   * テキストから防犯登録番号を抽出
-   * 6桁の数字パターンを検索（大阪府の防犯登録番号）
-   */
-  private extractRegistrationNumber(text: string): string | null {
-    // パターン1: "防犯登録" の後に続く6桁の数字を優先的に抽出
-    const afterRegistrationPattern = /防犯登録[\s\S]{0,50}?(\d{6})\b/;
-    const afterMatch = text.match(afterRegistrationPattern);
-    
-    if (afterMatch && afterMatch[1]) {
-      return afterMatch[1];
-    }
-
-    // パターン2: a217XXXXXXXXX のようなパターンから6桁部分を抽出
-    // （大阪府の防犯登録番号シール形式）
-    const osakaPattern = /a\d{11,12}a/gi;
-    const osakaMatches = text.match(osakaPattern);
-    
-    if (osakaMatches && osakaMatches.length > 0) {
-      // a217XXXXXX から最後の6桁を抽出
-      const numbers = osakaMatches[0].match(/\d+/);
-      if (numbers && numbers[0].length >= 6) {
-        const fullNumber = numbers[0];
-        return fullNumber.substring(fullNumber.length - 6); // 最後の6桁
-      }
-    }
-
-    // パターン3: 単独の6桁の数字
-    const directPattern = /\b\d{6}\b/g;
-    const directMatches = text.match(directPattern);
-    
-    if (directMatches && directMatches.length > 0) {
-      // 複数ある場合は、"防犯登録" や "大阪府警察" に近いものを優先
-      for (const match of directMatches) {
-        const index = text.indexOf(match);
-        const before = text.substring(Math.max(0, index - 50), index);
-        const after = text.substring(index, Math.min(text.length, index + 50));
-        
-        if (before.includes('防犯登録') || before.includes('大阪府警察') || 
-            after.includes('大阪府警察')) {
-          return match;
-        }
-      }
-      
-      // 見つからなければ最初のマッチを返す
-      return directMatches[0];
-    }
-
-    return null;
-  }
-
-  /**
-   * 信頼度スコアを計算（0.0-1.0）
-   * ページの認識精度から推定
-   */
-  private calculateConfidence(pages: any[]): number {
-    if (!pages || pages.length === 0) {
-      return 0;
-    }
-
-    // 簡易的な信頼度計算：ページ内の単語の信頼度平均
-    let totalConfidence = 0;
-    let wordCount = 0;
-
-    for (const page of pages) {
-      if (page.lines && Array.isArray(page.lines)) {
-        for (const line of page.lines) {
-          // line自体の信頼度がある場合
-          if (line.confidence !== undefined) {
-            totalConfidence += line.confidence;
-            wordCount++;
-          }
-          // wordsが配列の場合
-          if (line.words && Array.isArray(line.words)) {
-            for (const word of line.words) {
-              if (word.confidence !== undefined) {
-                totalConfidence += word.confidence;
-                wordCount++;
-              }
-            }
-          }
-        }
-      }
-      // ページレベルの信頼度もチェック
-      if (page.confidence !== undefined) {
-        totalConfidence += page.confidence;
-        wordCount++;
-      }
-    }
-
-    return wordCount > 0 ? totalConfidence / wordCount : 0.95; // デフォルト値
-  }
 }
 
-/**
- * OCRサービスシングルトンインスタンス
- */
 let ocrServiceInstance: OCRService | null = null;
 
 export function getOCRService(): OCRService {
@@ -169,7 +157,7 @@ export function getOCRService(): OCRService {
       );
     }
 
-    ocrServiceInstance = new OCRService(endpoint, apiKey);
+    ocrServiceInstance = new OCRService(new AzureDocumentAnalyzer(endpoint, apiKey));
   }
 
   return ocrServiceInstance;

--- a/backend/src/services/ownerUnlockService.ts
+++ b/backend/src/services/ownerUnlockService.ts
@@ -1,0 +1,179 @@
+import { BadRequestError, NotFoundError } from '../lib/errors';
+import { CouponService } from './couponService';
+
+type MarkerRecord = {
+  id: string;
+  code: string;
+};
+
+type DeclarationRecord = {
+  id: string;
+  markerId: string;
+  declaredAt: Date;
+  eligibleFinalAt: Date;
+  expiresAt: Date;
+  status: string;
+};
+
+type OwnerPrisma = {
+  marker: {
+    findUnique(args: { where: { code?: string; id?: string } }): Promise<MarkerRecord | null>;
+    create(args: { data: { code: string } }): Promise<MarkerRecord>;
+  };
+  declaration: {
+    findFirst(args: {
+      where: { markerId: string; status?: string };
+      orderBy: { declaredAt: 'asc' | 'desc' };
+    }): Promise<DeclarationRecord | null>;
+    create(args: {
+      data: {
+        markerId: string;
+        declaredAt: Date;
+        eligibleFinalAt: Date;
+        expiresAt: Date;
+        status: string;
+        notes?: string | null;
+      };
+    }): Promise<DeclarationRecord>;
+    update(args: {
+      where: { id: string };
+      data: { status: string; finalizedAt: Date };
+    }): Promise<DeclarationRecord>;
+  };
+};
+
+export class OwnerUnlockService {
+  constructor(
+    private readonly prisma: OwnerPrisma,
+    private readonly couponService: CouponService,
+    private readonly now: () => Date = () => new Date()
+  ) {}
+
+  async getCouponsByMarkerCode(code: string) {
+    const marker = await this.prisma.marker.findUnique({
+      where: { code },
+    });
+
+    if (!marker) {
+      throw new NotFoundError('Marker not found');
+    }
+
+    const coupons = await this.couponService.getCouponsByMarker(marker.id);
+    return {
+      markerId: marker.id,
+      code: marker.code,
+      coupons,
+    };
+  }
+
+  async createTemporaryUnlock(code: string, notes?: string) {
+    const marker = await this.getOrCreateMarker(code);
+    const declaredAt = this.now();
+    const eligibleFinalAt = new Date(declaredAt.getTime() + 15 * 60 * 1000);
+    const expiresAt = new Date(declaredAt.getTime() + 24 * 60 * 60 * 1000);
+
+    const declaration = await this.prisma.declaration.create({
+      data: {
+        markerId: marker.id,
+        declaredAt,
+        eligibleFinalAt,
+        expiresAt,
+        status: 'temporary',
+        notes: notes ?? null,
+      },
+    });
+
+    return {
+      declaredAt: declaration.declaredAt,
+      eligibleFinalAt: declaration.eligibleFinalAt,
+      expiresAt: declaration.expiresAt,
+      status: declaration.status,
+    };
+  }
+
+  async finalizeUnlock(code: string, input: { scannedCode?: string; ownerEmail?: string | null }) {
+    if (!input.scannedCode) {
+      throw new BadRequestError('scannedCode required');
+    }
+
+    if (input.scannedCode !== code) {
+      throw new BadRequestError('scannedCode does not match marker code');
+    }
+
+    const marker = await this.prisma.marker.findUnique({
+      where: { code },
+    });
+    if (!marker) {
+      throw new BadRequestError('No temporary declaration found');
+    }
+
+    const declaration = await this.prisma.declaration.findFirst({
+      where: {
+        markerId: marker.id,
+        status: 'temporary',
+      },
+      orderBy: { declaredAt: 'desc' },
+    });
+
+    if (!declaration) {
+      throw new BadRequestError('No temporary declaration found');
+    }
+
+    const finalizedAt = this.now();
+    if (finalizedAt < declaration.eligibleFinalAt) {
+      throw new BadRequestError('eligibleFinalAt has not arrived', {
+        eligibleFinalAt: declaration.eligibleFinalAt,
+        currentTime: finalizedAt,
+      });
+    }
+
+    await this.prisma.declaration.update({
+      where: { id: declaration.id },
+      data: {
+        status: 'resolved',
+        finalizedAt,
+      },
+    });
+
+    const coupon = await this.couponService.issueCouponForFinalUnlock(
+      marker.id,
+      input.ownerEmail ?? null,
+      finalizedAt
+    );
+
+    return {
+      finalizedAt,
+      status: 'resolved',
+      coupon: coupon
+        ? {
+            id: coupon.id,
+            name: coupon.name,
+            description: coupon.description,
+            shopName: coupon.shopName,
+            discount: coupon.discount,
+            discountType: coupon.discountType,
+            expiresAt: coupon.expiresAt,
+          }
+        : null,
+      message: coupon ? 'クーポンを獲得しました！商店街でご利用ください。' : '本解除が完了しました',
+    };
+  }
+
+  async useCoupon(id: string): Promise<boolean> {
+    return this.couponService.useCoupon(id, this.now());
+  }
+
+  private async getOrCreateMarker(code: string) {
+    const existing = await this.prisma.marker.findUnique({
+      where: { code },
+    });
+
+    if (existing) {
+      return existing;
+    }
+
+    return this.prisma.marker.create({
+      data: { code },
+    });
+  }
+}

--- a/backend/test/auth.spec.ts
+++ b/backend/test/auth.spec.ts
@@ -1,36 +1,15 @@
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 import { buildServer } from '../src/app';
 import bcrypt from 'bcryptjs';
-
-function makeMockPrisma() {
-  const users = new Map();
-  return {
-    user: {
-      findUnique: async ({ where: { email, id } }: any) => {
-        if (email) {
-          for (const u of users.values()) if (u.email === email) return u;
-          return null;
-        }
-        if (id) return users.get(id) || null;
-        return null;
-      },
-      create: async ({ data }: any) => {
-        const id = 'u-' + (users.size + 1);
-        const user = { id, ...data, createdAt: new Date() };
-        users.set(id, user);
-        return user;
-      },
-    },
-  };
-}
+import { createMockPrisma } from './helpers/mockPrisma';
 
 describe('auth', () => {
   let server: any;
   let mockPrisma: any;
 
   beforeAll(() => {
-    mockPrisma = makeMockPrisma();
-    server = buildServer({ prisma: mockPrisma });
+    mockPrisma = createMockPrisma();
+    server = buildServer({ prisma: mockPrisma.prisma as any });
   });
 
   afterAll(async () => {
@@ -53,7 +32,7 @@ describe('auth', () => {
     // create with hashed password
     const plain = 'secret123';
     const hashed = await bcrypt.hash(plain, 10);
-    const created = await mockPrisma.user.create({
+    await mockPrisma.prisma.user.create({
       data: { name: 'LoginUser', email: 'login@example.com', password: hashed },
     });
 
@@ -68,9 +47,31 @@ describe('auth', () => {
     expect(body).toHaveProperty('accessToken');
   });
 
+  it('rejects duplicate email on register', async () => {
+    const res = await server.inject({
+      method: 'POST',
+      url: '/auth/register',
+      payload: { email: 'vt@example.com', password: 'pass' },
+    });
+
+    expect(res.statusCode).toBe(409);
+    expect(JSON.parse(res.payload)).toEqual({ error: 'email already in use' });
+  });
+
+  it('rejects invalid credentials on login', async () => {
+    const res = await server.inject({
+      method: 'POST',
+      url: '/auth/login',
+      payload: { email: 'login@example.com', password: 'wrong-password' },
+    });
+
+    expect(res.statusCode).toBe(401);
+    expect(JSON.parse(res.payload)).toEqual({ error: 'invalid credentials' });
+  });
+
   it('accesses protected route /users/me', async () => {
     const hashed = await bcrypt.hash('p', 10);
-    const user = await mockPrisma.user.create({
+    const user = await mockPrisma.prisma.user.create({
       data: { name: 'Me', email: 'me@example.com', password: hashed },
     });
     // sign with server's jwt
@@ -84,5 +85,15 @@ describe('auth', () => {
     expect(res.statusCode).toBe(200);
     const body = JSON.parse(res.payload);
     expect(body.email).toBe('me@example.com');
+  });
+
+  it('rejects unauthorized access to /users/me', async () => {
+    const res = await server.inject({
+      method: 'GET',
+      url: '/users/me',
+    });
+
+    expect(res.statusCode).toBe(401);
+    expect(JSON.parse(res.payload)).toEqual({ error: 'Unauthorized' });
   });
 });

--- a/backend/test/bikes.spec.ts
+++ b/backend/test/bikes.spec.ts
@@ -1,48 +1,24 @@
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 import { buildServer } from '../src/app';
-
-function makeMockPrisma() {
-  const bikes = new Map();
-  return {
-    bike: {
-      findMany: async () => Array.from(bikes.values()),
-      findUnique: async ({ where: { id, serialNumber } }: any) => {
-        if (id) return bikes.get(id) || null;
-        if (serialNumber)
-          for (const b of bikes.values())
-            if (b.serialNumber === serialNumber) return b;
-        return null;
-      },
-      create: async ({ data }: any) => {
-        const id = 'b-' + (bikes.size + 1);
-        const bike = { id, ...data, createdAt: new Date() };
-        bikes.set(id, bike);
-        return bike;
-      },
-      update: async ({ where: { id }, data }: any) => {
-        const b = bikes.get(id);
-        if (!b) throw new Error('not found');
-        const updated = { ...b, ...data };
-        bikes.set(id, updated);
-        return updated;
-      },
-      delete: async ({ where: { id } }: any) => {
-        const b = bikes.get(id);
-        if (!b) throw new Error('not found');
-        bikes.delete(id);
-        return b;
-      },
-    },
-  };
-}
+import { createMockPrisma } from './helpers/mockPrisma';
 
 describe('bikes', () => {
   let server: any;
-  let mockPrisma: any;
+  let prismaBundle: ReturnType<typeof createMockPrisma>;
 
   beforeAll(() => {
-    mockPrisma = makeMockPrisma();
-    server = buildServer({ prisma: mockPrisma });
+    prismaBundle = createMockPrisma();
+    server = buildServer({
+      prisma: prismaBundle.prisma as any,
+      ocrService: {
+        recognizeRegistrationNumber: async () => ({
+          success: true,
+          registrationNumber: '12345678',
+          confidence: 0.91,
+          rawText: '防犯登録 12345678',
+        }),
+      },
+    });
   });
 
   afterAll(async () => {
@@ -93,5 +69,55 @@ describe('bikes', () => {
       url: `/bikes/${bike.id}`,
     });
     expect(delRes.statusCode).toBe(204);
+  });
+
+  it('rejects duplicate serial number', async () => {
+    const res = await server.inject({
+      method: 'POST',
+      url: '/bikes',
+      payload: { serialNumber: 'SN-1' },
+    });
+
+    expect(res.statusCode).toBe(409);
+    expect(JSON.parse(res.payload)).toEqual({ error: 'serialNumber already exists' });
+  });
+
+  it('returns 404 for missing bike', async () => {
+    const getRes = await server.inject({
+      method: 'GET',
+      url: '/bikes/missing-bike',
+    });
+    expect(getRes.statusCode).toBe(404);
+
+    const putRes = await server.inject({
+      method: 'PUT',
+      url: '/bikes/missing-bike',
+      payload: { status: 'maintenance' },
+    });
+    expect(putRes.statusCode).toBe(404);
+
+    const delRes = await server.inject({
+      method: 'DELETE',
+      url: '/bikes/missing-bike',
+    });
+    expect(delRes.statusCode).toBe(404);
+  });
+
+  it('maps OCR service results through the endpoint', async () => {
+    const res = await server.inject({
+      method: 'POST',
+      url: '/bikes/ocr/recognize',
+      payload: { filePath: '/tmp/sample.jpg' },
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(JSON.parse(res.payload)).toEqual({
+      success: true,
+      result: {
+        registrationNumber: '12345678',
+        confidence: 0.91,
+        rawText: '防犯登録 12345678',
+      },
+    });
   });
 });

--- a/backend/test/helpers/mockPrisma.ts
+++ b/backend/test/helpers/mockPrisma.ts
@@ -1,0 +1,446 @@
+type UserRecord = {
+  id: string;
+  name: string | null;
+  email: string;
+  password: string;
+  role: string;
+  createdAt: Date;
+  updatedAt: Date;
+};
+
+type BikeRecord = {
+  id: string;
+  serialNumber: string;
+  status: string;
+  location: string | null;
+  createdAt: Date;
+  updatedAt: Date;
+};
+
+type MarkerRecord = {
+  id: string;
+  code: string;
+  location: string | null;
+  createdAt: Date;
+  updatedAt: Date;
+};
+
+type DeclarationRecord = {
+  id: string;
+  markerId: string;
+  declaredAt: Date;
+  eligibleFinalAt: Date;
+  expiresAt: Date;
+  finalizedAt: Date | null;
+  status: string;
+  notes: string | null;
+  createdAt: Date;
+  updatedAt: Date;
+};
+
+type CouponRecord = {
+  id: string;
+  name: string;
+  description: string;
+  shopName: string;
+  discount: number;
+  discountType: string;
+  validDays: number;
+  isActive: boolean;
+  createdAt: Date;
+  updatedAt: Date;
+};
+
+type CouponIssuanceRecord = {
+  id: string;
+  couponId: string;
+  userId: string | null;
+  markerId: string | null;
+  ownerEmail: string | null;
+  issuedAt: Date;
+  expiresAt: Date;
+  usedAt: Date | null;
+  status: string;
+  createdAt: Date;
+  updatedAt: Date;
+};
+
+type SelectShape = Record<string, boolean>;
+
+function pickSelected<T extends Record<string, unknown>>(record: T, select?: SelectShape) {
+  if (!select) {
+    return record;
+  }
+
+  const selectedEntries = Object.entries(select)
+    .filter(([, enabled]) => enabled)
+    .map(([key]) => [key, record[key]]);
+
+  return Object.fromEntries(selectedEntries);
+}
+
+function sortByDateDesc<T>(items: T[], getter: (value: T) => Date) {
+  return [...items].sort((left, right) => getter(right).getTime() - getter(left).getTime());
+}
+
+export function createMockPrisma() {
+  const users = new Map<string, UserRecord>();
+  const bikes = new Map<string, BikeRecord>();
+  const markers = new Map<string, MarkerRecord>();
+  const declarations = new Map<string, DeclarationRecord>();
+  const coupons = new Map<string, CouponRecord>();
+  const couponIssuances = new Map<string, CouponIssuanceRecord>();
+
+  const counters = {
+    user: 0,
+    bike: 0,
+    marker: 0,
+    declaration: 0,
+    coupon: 0,
+    issuance: 0,
+  };
+
+  const prisma = {
+    user: {
+      findUnique: async ({ where, select }: { where: { email?: string; id?: string }; select?: SelectShape }) => {
+        let user: UserRecord | null = null;
+
+        if (where.id) {
+          user = users.get(where.id) ?? null;
+        } else if (where.email) {
+          user = Array.from(users.values()).find((entry) => entry.email === where.email) ?? null;
+        }
+
+        return user ? pickSelected(user, select) : null;
+      },
+      create: async ({
+        data,
+        select,
+      }: {
+        data: { name?: string | null; email: string; password: string; role?: string };
+        select?: SelectShape;
+      }) => {
+        counters.user += 1;
+        const now = new Date();
+        const record: UserRecord = {
+          id: `u-${counters.user}`,
+          name: data.name ?? null,
+          email: data.email,
+          password: data.password,
+          role: data.role ?? 'user',
+          createdAt: now,
+          updatedAt: now,
+        };
+        users.set(record.id, record);
+        return pickSelected(record, select);
+      },
+    },
+    bike: {
+      findMany: async () => Array.from(bikes.values()),
+      findUnique: async ({
+        where,
+      }: {
+        where: { id?: string; serialNumber?: string };
+      }) => {
+        if (where.id) {
+          return bikes.get(where.id) ?? null;
+        }
+
+        if (where.serialNumber) {
+          return Array.from(bikes.values()).find((entry) => entry.serialNumber === where.serialNumber) ?? null;
+        }
+
+        return null;
+      },
+      create: async ({
+        data,
+      }: {
+        data: { serialNumber: string; location?: string | null; status?: string };
+      }) => {
+        counters.bike += 1;
+        const now = new Date();
+        const record: BikeRecord = {
+          id: `b-${counters.bike}`,
+          serialNumber: data.serialNumber,
+          location: data.location ?? null,
+          status: data.status ?? 'available',
+          createdAt: now,
+          updatedAt: now,
+        };
+        bikes.set(record.id, record);
+        return record;
+      },
+      update: async ({
+        where,
+        data,
+      }: {
+        where: { id: string };
+        data: { location?: string | null; status?: string };
+      }) => {
+        const existing = bikes.get(where.id);
+        if (!existing) {
+          throw new Error('not found');
+        }
+
+        const updated: BikeRecord = {
+          ...existing,
+          location: data.location ?? existing.location,
+          status: data.status ?? existing.status,
+          updatedAt: new Date(),
+        };
+        bikes.set(where.id, updated);
+        return updated;
+      },
+      delete: async ({ where }: { where: { id: string } }) => {
+        const existing = bikes.get(where.id);
+        if (!existing) {
+          throw new Error('not found');
+        }
+
+        bikes.delete(where.id);
+        return existing;
+      },
+    },
+    marker: {
+      findUnique: async ({ where }: { where: { code?: string; id?: string } }) => {
+        if (where.id) {
+          return markers.get(where.id) ?? null;
+        }
+
+        if (where.code) {
+          return Array.from(markers.values()).find((entry) => entry.code === where.code) ?? null;
+        }
+
+        return null;
+      },
+      create: async ({ data }: { data: { code: string; location?: string | null } }) => {
+        counters.marker += 1;
+        const now = new Date();
+        const record: MarkerRecord = {
+          id: `m-${counters.marker}`,
+          code: data.code,
+          location: data.location ?? null,
+          createdAt: now,
+          updatedAt: now,
+        };
+        markers.set(record.id, record);
+        return record;
+      },
+    },
+    declaration: {
+      findFirst: async ({
+        where,
+      }: {
+        where: { markerId: string; status?: string };
+        orderBy?: { declaredAt: 'asc' | 'desc' };
+      }) => {
+        const filtered = Array.from(declarations.values()).filter((entry) => {
+          return entry.markerId === where.markerId && (!where.status || entry.status === where.status);
+        });
+
+        return sortByDateDesc(filtered, (entry) => entry.declaredAt)[0] ?? null;
+      },
+      create: async ({
+        data,
+      }: {
+        data: {
+          markerId: string;
+          declaredAt: Date;
+          eligibleFinalAt: Date;
+          expiresAt: Date;
+          status: string;
+          notes?: string | null;
+        };
+      }) => {
+        counters.declaration += 1;
+        const now = new Date();
+        const record: DeclarationRecord = {
+          id: `d-${counters.declaration}`,
+          markerId: data.markerId,
+          declaredAt: data.declaredAt,
+          eligibleFinalAt: data.eligibleFinalAt,
+          expiresAt: data.expiresAt,
+          status: data.status,
+          notes: data.notes ?? null,
+          finalizedAt: null,
+          createdAt: now,
+          updatedAt: now,
+        };
+        declarations.set(record.id, record);
+        return record;
+      },
+      update: async ({
+        where,
+        data,
+      }: {
+        where: { id: string };
+        data: { status?: string; finalizedAt?: Date | null };
+      }) => {
+        const existing = declarations.get(where.id);
+        if (!existing) {
+          throw new Error('not found');
+        }
+
+        const updated: DeclarationRecord = {
+          ...existing,
+          status: data.status ?? existing.status,
+          finalizedAt: data.finalizedAt ?? existing.finalizedAt,
+          updatedAt: new Date(),
+        };
+        declarations.set(where.id, updated);
+        return updated;
+      },
+    },
+    coupon: {
+      findFirst: async ({
+        where,
+      }: {
+        where?: { isActive?: boolean };
+        orderBy?: { createdAt: 'asc' | 'desc' };
+      }) => {
+        const filtered = Array.from(coupons.values()).filter((entry) => {
+          return where?.isActive === undefined ? true : entry.isActive === where.isActive;
+        });
+
+        return sortByDateDesc(filtered, (entry) => entry.createdAt)[0] ?? null;
+      },
+      count: async () => coupons.size,
+      createMany: async ({ data }: { data: Array<Omit<CouponRecord, 'id' | 'createdAt' | 'updatedAt'>> }) => {
+        for (const item of data) {
+          counters.coupon += 1;
+          const now = new Date();
+          const record: CouponRecord = {
+            id: `c-${counters.coupon}`,
+            createdAt: now,
+            updatedAt: now,
+            ...item,
+          };
+          coupons.set(record.id, record);
+        }
+
+        return { count: data.length };
+      },
+    },
+    couponIssuance: {
+      create: async ({
+        data,
+        include,
+      }: {
+        data: {
+          couponId: string;
+          markerId?: string | null;
+          userId?: string | null;
+          ownerEmail?: string | null;
+          expiresAt: Date;
+          status: string;
+        };
+        include?: { coupon?: boolean };
+      }) => {
+        counters.issuance += 1;
+        const now = new Date();
+        const record: CouponIssuanceRecord = {
+          id: `ci-${counters.issuance}`,
+          couponId: data.couponId,
+          markerId: data.markerId ?? null,
+          userId: data.userId ?? null,
+          ownerEmail: data.ownerEmail ?? null,
+          expiresAt: data.expiresAt,
+          status: data.status,
+          issuedAt: now,
+          usedAt: null,
+          createdAt: now,
+          updatedAt: now,
+        };
+        couponIssuances.set(record.id, record);
+
+        if (include?.coupon) {
+          return {
+            ...record,
+            coupon: coupons.get(record.couponId)!,
+          };
+        }
+
+        return record;
+      },
+      findMany: async ({
+        where,
+        include,
+      }: {
+        where: { markerId?: string; status?: { in: string[] } };
+        include?: { coupon?: boolean };
+        orderBy?: { issuedAt: 'asc' | 'desc' };
+      }) => {
+        const filtered = Array.from(couponIssuances.values()).filter((entry) => {
+          const matchesMarker = where.markerId === undefined ? true : entry.markerId === where.markerId;
+          const matchesStatus = where.status?.in ? where.status.in.includes(entry.status) : true;
+          return matchesMarker && matchesStatus;
+        });
+
+        return sortByDateDesc(filtered, (entry) => entry.issuedAt).map((entry) => {
+          if (include?.coupon) {
+            return {
+              ...entry,
+              coupon: coupons.get(entry.couponId)!,
+            };
+          }
+
+          return entry;
+        });
+      },
+      findUnique: async ({ where }: { where: { id: string } }) => {
+        return couponIssuances.get(where.id) ?? null;
+      },
+      update: async ({
+        where,
+        data,
+      }: {
+        where: { id: string };
+        data: { status?: string; usedAt?: Date | null };
+      }) => {
+        const existing = couponIssuances.get(where.id);
+        if (!existing) {
+          throw new Error('not found');
+        }
+
+        const updated: CouponIssuanceRecord = {
+          ...existing,
+          status: data.status ?? existing.status,
+          usedAt: data.usedAt ?? existing.usedAt,
+          updatedAt: new Date(),
+        };
+        couponIssuances.set(where.id, updated);
+        return updated;
+      },
+    },
+  };
+
+  return {
+    prisma,
+    state: {
+      users,
+      bikes,
+      markers,
+      declarations,
+      coupons,
+      couponIssuances,
+    },
+    seedCoupon(data: Partial<Omit<CouponRecord, 'id' | 'createdAt' | 'updatedAt'>> = {}) {
+      counters.coupon += 1;
+      const now = new Date();
+      const record: CouponRecord = {
+        id: `c-${counters.coupon}`,
+        name: data.name ?? '商店街お買い物券500円',
+        description: data.description ?? '商店街の加盟店で使える500円分のお買い物券',
+        shopName: data.shopName ?? '北区商店街',
+        discount: data.discount ?? 500,
+        discountType: data.discountType ?? 'amount',
+        validDays: data.validDays ?? 30,
+        isActive: data.isActive ?? true,
+        createdAt: now,
+        updatedAt: now,
+      };
+      coupons.set(record.id, record);
+      return record;
+    },
+  };
+}

--- a/backend/test/ocr.spec.ts
+++ b/backend/test/ocr.spec.ts
@@ -1,103 +1,62 @@
-import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
-import { OCRService } from '../src/services/ocrService';
-import { writeFileSync, unlinkSync } from 'fs';
-import { join } from 'path';
+import { describe, it, expect } from 'vitest';
+import {
+  OCRService,
+  calculateConfidence,
+  extractRegistrationNumber,
+} from '../src/services/ocrService';
 
 describe('OCRService', () => {
-  let ocrService: OCRService;
-
-  beforeAll(() => {
-    // テスト用のOCRサービスインスタンスを作成
-    // ダミーのエンドポイントとキーを使用（実際のAPI呼び出しは行わない）
-    const endpoint = process.env.AZURE_FORM_RECOGNIZER_ENDPOINT || 'https://test.cognitiveservices.azure.com/';
-    const apiKey = process.env.AZURE_FORM_RECOGNIZER_KEY || 'test-key';
-
-    try {
-      ocrService = new OCRService(endpoint, apiKey);
-    } catch (e) {
-      // 初期化エラーは無視
-    }
-  });
-
   describe('extractRegistrationNumber', () => {
     it('8桁の防犯登録番号を抽出できる', () => {
-      if (!ocrService) {
-        console.warn('OCRService が初期化されていません。テストをスキップします。');
-        expect(true).toBe(true);
-        return;
-      }
-      // プライベートメソッドへのアクセスをテストするためのユーティリティ
       const testText = '自転車の防犯登録番号は 12345678 です';
-      const result = (ocrService as any).extractRegistrationNumber(testText);
+      const result = extractRegistrationNumber(testText);
       expect(result).toBe('12345678');
     });
 
     it('10桁の防犯登録番号を抽出できる', () => {
-      if (!ocrService) {
-        expect(true).toBe(true);
-        return;
-      }
       const testText = '登録番号: 1234567890';
-      const result = (ocrService as any).extractRegistrationNumber(testText);
+      const result = extractRegistrationNumber(testText);
       expect(result).toBe('1234567890');
     });
 
     it('複数の数字がある場合は最初の8~10桁を返す', () => {
-      if (!ocrService) {
-        expect(true).toBe(true);
-        return;
-      }
       const testText = '前回: 11111111 今回: 22222222';
-      const result = (ocrService as any).extractRegistrationNumber(testText);
+      const result = extractRegistrationNumber(testText);
       expect(result).toBe('11111111');
     });
 
     it('防犯登録番号がない場合はnullを返す', () => {
-      if (!ocrService) {
-        expect(true).toBe(true);
-        return;
-      }
       const testText = 'これは防犯登録番号を含まないテキストです';
-      const result = (ocrService as any).extractRegistrationNumber(testText);
+      const result = extractRegistrationNumber(testText);
       expect(result).toBeNull();
     });
 
     it('7桁の数字は抽出しない', () => {
-      if (!ocrService) {
-        expect(true).toBe(true);
-        return;
-      }
       const testText = '番号は 1234567 です';
-      const result = (ocrService as any).extractRegistrationNumber(testText);
+      const result = extractRegistrationNumber(testText);
       expect(result).toBeNull();
     });
 
     it('11桁以上の数字は抽出しない', () => {
-      if (!ocrService) {
-        expect(true).toBe(true);
-        return;
-      }
       const testText = '番号は 12345678901 です';
-      const result = (ocrService as any).extractRegistrationNumber(testText);
+      const result = extractRegistrationNumber(testText);
       expect(result).toBeNull();
+    });
+
+    it('大阪府シール形式から末尾6桁を抽出できる', () => {
+      const testText = '識別子 a217123456789a を読み取りました';
+      const result = extractRegistrationNumber(testText);
+      expect(result).toBe('456789');
     });
   });
 
   describe('calculateConfidence', () => {
     it('ページが空の場合は0を返す', () => {
-      if (!ocrService) {
-        expect(true).toBe(true);
-        return;
-      }
-      const result = (ocrService as any).calculateConfidence([]);
+      const result = calculateConfidence([]);
       expect(result).toBe(0);
     });
 
     it('単語の信頼度から平均を計算する', () => {
-      if (!ocrService) {
-        expect(true).toBe(true);
-        return;
-      }
       const mockPages = [
         {
           lines: [
@@ -110,15 +69,11 @@ describe('OCRService', () => {
           ],
         },
       ];
-      const result = (ocrService as any).calculateConfidence(mockPages);
+      const result = calculateConfidence(mockPages);
       expect(result).toBe(0.925); // (0.95 + 0.90) / 2
     });
 
     it('複数のページから信頼度を計算する', () => {
-      if (!ocrService) {
-        expect(true).toBe(true);
-        return;
-      }
       const mockPages = [
         {
           lines: [
@@ -135,31 +90,52 @@ describe('OCRService', () => {
           ],
         },
       ];
-      const result = (ocrService as any).calculateConfidence(mockPages);
+      const result = calculateConfidence(mockPages);
       expect(result).toBe(0.9); // (1.0 + 0.8) / 2
     });
   });
 
   describe('recognizeRegistrationNumber', () => {
     it('ファイルが存在しない場合はエラーを返す', async () => {
-      if (!ocrService) {
-        expect(true).toBe(true);
-        return;
-      }
+      const ocrService = new OCRService({
+        analyzeDocument: async () => ({
+          content: '防犯登録 12345678',
+          pages: [],
+        }),
+      });
+
       const result = await ocrService.recognizeRegistrationNumber('/nonexistent/path.jpg');
       expect(result.success).toBe(false);
       expect(result.registrationNumber).toBeNull();
       expect(result.error).toBeDefined();
     });
 
-    it('OCR実行時にエラーが発生した場合は適切に処理される', async () => {
-      if (!ocrService) {
-        expect(true).toBe(true);
-        return;
-      }
-      // このテストは実際のAzure呼び出しのため、統合テストとして実装
-      // ローカルユニットテストでは実行スキップ
-      expect(true).toBe(true);
+    it('分析結果から registrationNumber と confidence を返す', async () => {
+      const ocrService = new OCRService(
+        {
+          analyzeDocument: async () => ({
+            content: '防犯登録 12345678',
+            pages: [
+              {
+                lines: [
+                  {
+                    words: [{ confidence: 0.8 }, { confidence: 1.0 }],
+                  },
+                ],
+              },
+            ],
+          }),
+        },
+        () => Buffer.from('test-image')
+      );
+
+      const result = await ocrService.recognizeRegistrationNumber('/tmp/image.jpg');
+      expect(result).toEqual({
+        success: true,
+        registrationNumber: '12345678',
+        confidence: 0.9,
+        rawText: '防犯登録 12345678',
+      });
     });
   });
 });

--- a/backend/test/owner.spec.ts
+++ b/backend/test/owner.spec.ts
@@ -1,0 +1,180 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { buildServer } from '../src/app';
+import { createMockPrisma } from './helpers/mockPrisma';
+
+describe('owner', () => {
+  let server: any;
+  let prismaBundle: ReturnType<typeof createMockPrisma>;
+  let currentTime: Date;
+
+  beforeAll(() => {
+    prismaBundle = createMockPrisma();
+    currentTime = new Date('2026-04-20T09:00:00.000Z');
+    server = buildServer({
+      prisma: prismaBundle.prisma as any,
+      now: () => currentTime,
+    });
+  });
+
+  afterAll(async () => {
+    await server.close();
+  });
+
+  it('creates a temporary unlock declaration', async () => {
+    const response = await server.inject({
+      method: 'POST',
+      url: '/owner/markers/ABC123/unlock-temp',
+      payload: { notes: '移動済み' },
+    });
+
+    expect(response.statusCode).toBe(200);
+    const body = JSON.parse(response.payload);
+    expect(body.status).toBe('temporary');
+    expect(body.declaredAt).toBe('2026-04-20T09:00:00.000Z');
+    expect(body.eligibleFinalAt).toBe('2026-04-20T09:15:00.000Z');
+    expect(body.expiresAt).toBe('2026-04-21T09:00:00.000Z');
+  });
+
+  it('rejects final unlock when no temporary declaration exists', async () => {
+    const response = await server.inject({
+      method: 'POST',
+      url: '/owner/markers/NO-DECLARATION/unlock-final',
+      payload: { scannedCode: 'NO-DECLARATION' },
+    });
+
+    expect(response.statusCode).toBe(400);
+    expect(JSON.parse(response.payload)).toEqual({ error: 'No temporary declaration found' });
+  });
+
+  it('rejects final unlock before eligibleFinalAt', async () => {
+    const response = await server.inject({
+      method: 'POST',
+      url: '/owner/markers/ABC123/unlock-final',
+      payload: { scannedCode: 'ABC123' },
+    });
+
+    expect(response.statusCode).toBe(400);
+    expect(JSON.parse(response.payload)).toMatchObject({
+      error: 'eligibleFinalAt has not arrived',
+      eligibleFinalAt: '2026-04-20T09:15:00.000Z',
+    });
+  });
+
+  it('rejects final unlock when scannedCode does not match', async () => {
+    currentTime = new Date('2026-04-20T09:20:00.000Z');
+
+    const response = await server.inject({
+      method: 'POST',
+      url: '/owner/markers/ABC123/unlock-final',
+      payload: { scannedCode: 'DIFFERENT-CODE' },
+    });
+
+    expect(response.statusCode).toBe(400);
+    expect(JSON.parse(response.payload)).toEqual({
+      error: 'scannedCode does not match marker code',
+    });
+  });
+
+  it('finalizes unlock and issues a coupon when available', async () => {
+    prismaBundle.seedCoupon();
+
+    const response = await server.inject({
+      method: 'POST',
+      url: '/owner/markers/ABC123/unlock-final',
+      payload: { scannedCode: 'ABC123', ownerEmail: 'owner@example.com' },
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(JSON.parse(response.payload)).toMatchObject({
+      status: 'resolved',
+      message: 'クーポンを獲得しました！商店街でご利用ください。',
+      coupon: {
+        name: '商店街お買い物券500円',
+        shopName: '北区商店街',
+        discount: 500,
+      },
+    });
+  });
+
+  it('returns a resolved response without coupon when no active coupon exists', async () => {
+    currentTime = new Date('2026-04-20T10:00:00.000Z');
+
+    const tempResponse = await server.inject({
+      method: 'POST',
+      url: '/owner/markers/NO-COUPON/unlock-temp',
+      payload: {},
+    });
+    expect(tempResponse.statusCode).toBe(200);
+
+    currentTime = new Date('2026-04-20T10:20:00.000Z');
+    prismaBundle.state.coupons.clear();
+
+    const response = await server.inject({
+      method: 'POST',
+      url: '/owner/markers/NO-COUPON/unlock-final',
+      payload: { scannedCode: 'NO-COUPON' },
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(JSON.parse(response.payload)).toMatchObject({
+      status: 'resolved',
+      coupon: null,
+      message: '本解除が完了しました',
+    });
+  });
+
+  it('lists and uses coupons, and rejects expired coupons', async () => {
+    currentTime = new Date('2026-04-20T11:00:00.000Z');
+    prismaBundle.seedCoupon({ validDays: 1 });
+
+    await server.inject({
+      method: 'POST',
+      url: '/owner/markers/USE-COUPON/unlock-temp',
+      payload: {},
+    });
+
+    currentTime = new Date('2026-04-20T11:20:00.000Z');
+    await server.inject({
+      method: 'POST',
+      url: '/owner/markers/USE-COUPON/unlock-final',
+      payload: { scannedCode: 'USE-COUPON' },
+    });
+
+    const listResponse = await server.inject({
+      method: 'GET',
+      url: '/owner/markers/USE-COUPON/coupons',
+    });
+
+    expect(listResponse.statusCode).toBe(200);
+    const coupons = JSON.parse(listResponse.payload).coupons;
+    expect(coupons).toHaveLength(1);
+
+    const useResponse = await server.inject({
+      method: 'POST',
+      url: `/owner/coupons/${coupons[0].id}/use`,
+    });
+    expect(useResponse.statusCode).toBe(200);
+
+    const reuseResponse = await server.inject({
+      method: 'POST',
+      url: `/owner/coupons/${coupons[0].id}/use`,
+    });
+    expect(reuseResponse.statusCode).toBe(400);
+
+    const expiredCoupon = prismaBundle.seedCoupon({ validDays: 1 });
+    const expiredIssuance = await prismaBundle.prisma.couponIssuance.create({
+      data: {
+        couponId: expiredCoupon.id,
+        markerId: 'expired-marker',
+        expiresAt: new Date('2026-04-19T00:00:00.000Z'),
+        status: 'active',
+      },
+    });
+
+    const expiredResponse = await server.inject({
+      method: 'POST',
+      url: `/owner/coupons/${expiredIssuance.id}/use`,
+    });
+    expect(expiredResponse.statusCode).toBe(400);
+  });
+});

--- a/docs/api-spec.md
+++ b/docs/api-spec.md
@@ -140,10 +140,10 @@
 
 - 説明: QR からアクセスした持ち主に、対象マーカーの警告内容、通報状態、仮解除情報を返す
 
-### GET /api/owner/markers/:code/coupons（将来構想）
+### GET /api/owner/markers/:code/coupons（実装済み・将来拡張）
 
 - 説明: 指定マーカーに紐づくクーポン発行履歴を返す
-- 今回スコープ: ポイント/クーポンの存在は示すが、詳細な発行・利用管理は必須 API に含めない
+- 今回スコープ: 実装は存在するが、詳細な発行・利用管理は必須 API に含めない
 
 ### POST /api/owner/markers/:code/unlock-temp
 
@@ -154,9 +154,9 @@
 
 - 説明: 持ち主が本解除を実行（`eligibleFinalAt` 到達後）
 - Body: `{ "scannedCode": string, "ownerEmail"?: string }`
-- 備考: QR再スキャン照合は試作品の解除体験として利用候補とする。クーポン発行処理は今回スコープ外の将来構想として扱う。
+- 備考: `scannedCode` は必須。QR再スキャン照合で `:code` と一致した場合のみ本解除される。クーポン発行処理は backend に実装されているが、試作品の必須要件には含めない。
 
-### POST /api/owner/coupons/:id/use（将来構想）
+### POST /api/owner/coupons/:id/use（実装済み・将来拡張）
 
 - 説明: 発行済みクーポンを利用済みに更新
 - 今回スコープ: 試作品では必須 API に含めない

--- a/docs/openapi-owner.yaml
+++ b/docs/openapi-owner.yaml
@@ -53,6 +53,12 @@ paths:
           required: true
           schema:
             type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/FinalizeRequest'
       responses:
         '200':
           description: Finalized
@@ -91,35 +97,55 @@ components:
     TemporaryUnlockResponse:
       type: object
       properties:
+        declaredAt:
+          type: string
+          format: date-time
+        eligibleFinalAt:
+          type: string
+          format: date-time
+        expiresAt:
+          type: string
+          format: date-time
         status:
           type: string
-          example: ok
-        data:
-          type: object
-          properties:
-            declaredAt:
-              type: string
-              format: date-time
-            eligibleFinalAt:
-              type: string
-              format: date-time
-            expiresAt:
-              type: string
-              format: date-time
-            status:
-              type: string
-              example: temporary
+          example: temporary
     FinalizeResponse:
       type: object
       properties:
+        finalizedAt:
+          type: string
+          format: date-time
         status:
           type: string
-        data:
+          example: resolved
+        message:
+          type: string
+        coupon:
           type: object
+          nullable: true
           properties:
-            finalizedAt:
+            id:
+              type: string
+            name:
+              type: string
+            description:
+              type: string
+            shopName:
+              type: string
+            discount:
+              type: number
+            discountType:
+              type: string
+            expiresAt:
               type: string
               format: date-time
-            status:
-              type: string
-              example: resolved
+    FinalizeRequest:
+      type: object
+      required:
+        - scannedCode
+      properties:
+        scannedCode:
+          type: string
+        ownerEmail:
+          type: string
+          format: email

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -141,7 +141,7 @@ paths:
       parameters:
         - $ref: "#/components/parameters/MarkerCode"
       requestBody:
-        required: false
+        required: true
         content:
           application/json:
             schema:
@@ -278,9 +278,14 @@ components:
           enum: [temporary]
     UnlockFinalBody:
       type: object
+      required:
+        - scannedCode
       properties:
         scannedCode:
           type: string
+        ownerEmail:
+          type: string
+          format: email
     UnlockFinalResponse:
       type: object
       properties:
@@ -290,3 +295,24 @@ components:
         status:
           type: string
           enum: [resolved]
+        message:
+          type: string
+        coupon:
+          type: object
+          nullable: true
+          properties:
+            id:
+              type: string
+            name:
+              type: string
+            description:
+              type: string
+            shopName:
+              type: string
+            discount:
+              type: number
+            discountType:
+              type: string
+            expiresAt:
+              type: string
+              format: date-time

--- a/docs/owner-api.md
+++ b/docs/owner-api.md
@@ -87,13 +87,14 @@ QRコードでアクセスする持ち主向けの簡易Webフロー向けAPI仕
 }
 ```
 
-- クーポン発行を行う場合のレスポンス拡張は将来構想とする。
+- 実装上はクーポンが有効な場合に `coupon` オブジェクトを含めて返す。
+- クーポン発行/利用 API 自体は backend に存在するが、試作品の必須受入基準には含めない。
 
 - エラーレスポンス例:
 
 ```json
 {
-  "error": "no declaration found"
+  "error": "No temporary declaration found"
 }
 ```
 
@@ -103,10 +104,10 @@ QRコードでアクセスする持ち主向けの簡易Webフロー向けAPI仕
 }
 ```
 
-### GET /api/owner/markers/{code}/coupons（将来構想）
+### GET /api/owner/markers/{code}/coupons（実装済み・将来拡張）
 
 - 説明: 指定マーカーに紐づく発行済みクーポンを取得
-- 今回スコープ: 試作品では必須 API に含めない
+- 今回スコープ: backend には実装済みだが、試作品では必須 API に含めない
 - ステータスコード: 200 OK
 - レスポンス例:
 
@@ -127,10 +128,10 @@ QRコードでアクセスする持ち主向けの簡易Webフロー向けAPI仕
 }
 ```
 
-### POST /api/owner/coupons/{id}/use（将来構想）
+### POST /api/owner/coupons/{id}/use（実装済み・将来拡張）
 
 - 説明: クーポンを利用済みに更新
-- 今回スコープ: 試作品では必須 API に含めない
+- 今回スコープ: backend には実装済みだが、試作品では必須 API に含めない
 - ステータスコード: 200 OK（成功）、400 Bad Request（使用不可）
 
 ---
@@ -154,7 +155,7 @@ QRコードでアクセスする持ち主向けの簡易Webフロー向けAPI仕
   - `id`, `marker_id`, `report_id`, `declared_at`, `eligible_final_at`, `expires_at`, `status` (temporary|finalized|expired), `finalized_at`, `ip`, `user_agent`, `notes`
 - `bicycle_reports.status` は `reported|temporary|resolved|collection_requested|collected|not_found_on_collection` をサポート
 - テーブル `coupon_issuances`:
-  - 将来構想。`id`, `coupon_id`, `marker_id`, `owner_email`, `issued_at`, `expires_at`, `used_at`, `status`
+  - backend 実装済み。`id`, `coupon_id`, `marker_id`, `owner_email`, `issued_at`, `expires_at`, `used_at`, `status`
 - テーブル `audit_logs`:
   - `id`, `action_type`, `marker_code`, `ip`, `user_agent`, `risk_score`, `created_at`
 
@@ -171,7 +172,7 @@ QRコードでアクセスする持ち主向けの簡易Webフロー向けAPI仕
 
 - すべての解除操作（仮/本）は `ip`, `user_agent`, `timestamp` を保存
 - 異常なパターン (短期間に大量解除) の高度なアラートは将来構想
-- 本解除時のクーポン発行/利用イベントは将来構想
+- 本解除時のクーポン発行/利用イベントは backend に試作実装あり。運用設計は将来構想
 - 将来的な盗難照合（警察連携）のための防犯登録番号照会イベントは将来構想
 
 ---

--- a/plan/2026-04-20__backend-refactor.md
+++ b/plan/2026-04-20__backend-refactor.md
@@ -1,0 +1,52 @@
+# Backend Refactor Plan
+
+## Goal and non-goals
+
+- Goal: route に直書きされた検証・DB操作・レスポンス整形を service 層へ寄せ、型とテストを揃える。
+- Goal: `unlock-final` の `scannedCode` 検証を実装し、owner flow と OCR の期待挙動をテストで固定する。
+- Non-goal: Prisma schema 変更、API の大幅な再設計、将来構想機能の削除。
+
+## Files and docs inspected
+
+- `backend/src/app.ts`
+- `backend/src/routes/*.ts`
+- `backend/src/services/*.ts`
+- `backend/test/*.spec.ts`
+- `backend/prisma/schema.prisma`
+- `backend/README.md`
+- `docs/owner-api.md`
+- `docs/api-spec.md`
+- `docs/openapi.yaml`
+- `docs/openapi-owner.yaml`
+
+## Planned changes
+
+- 共通エラー変換を追加して route の責務を薄くする。
+- `auth` `bikes` `owner` の service を分割し、route は request/response と status code に集中させる。
+- OCR は Azure 呼び出しと抽出ロジックを分離し、純粋関数テストを追加する。
+- Prisma モックを共通化し、auth/bikes/owner の route テストで使い回す。
+- docs は `unlock-final` の body と coupon API の扱いだけ現実に合わせる。
+
+## Verification commands
+
+- `cd backend && npm test`
+- `cd backend && npm run build`
+- `git diff --stat`
+- `git status --short`
+
+## Data/API assumptions
+
+- coupon API は削除せず残すが、試作品の必須受入基準には含めない。
+- `POST /owner/markers/:code/unlock-final` は `scannedCode` 必須、`ownerEmail` 任意。
+- OCR は 8-10 桁を基本とし、大阪府シール形式は末尾 6 桁抽出を特例として残す。
+
+## Risks and follow-ups
+
+- 実行環境に Node.js / npm が無い場合、ローカル検証は未実施になる。
+- `docs/backend-spec.md` には将来構想寄りの概念モデルが残るため、次回 API 実装拡張時に再整理が必要。
+
+## Project docs updates
+
+- `AGENTS.md`: 更新不要
+- `ARCHITECTURE.md`: 更新不要
+- `docs/adr/`: 今回の変更では不要


### PR DESCRIPTION
## 概要
- Fastify route に直書きされていた認証、自転車CRUD、owner解除、OCR処理を service 層へ分離
- 共通エラー変換とテスト用 Prisma モックを追加
- owner unlock-final に scannedCode 照合を追加し、クーポンAPIは維持したまま境界を整理
- OCR の抽出ロジックと confidence 計算を純粋関数化
- 関連 docs / OpenAPI / plan を更新

## 検証
- git diff --check: 成功
- npm test: 未実施（環境に node / npm がありません）
- npm run build: 未実施（環境に node / npm がありません）
- yarn test: 実行不可（この環境の yarn は Node.js yarn ではなく、test ディレクトリをシナリオとして解釈して失敗）