### PR TITLE
Issue #25 通報登録APIを実装

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -13,7 +13,7 @@ NO-Houchi Bicycle Net is a monorepo for a prototype civic-tech platform targetin
 
 ## Main Flows
 
-- Supporter/reporting flow: abandoned bicycle information is recorded through backend APIs and data models.
+- Supporter/reporting flow: abandoned bicycle information is recorded through the backend report registration API and persisted in backend data models.
 - Owner flow: a marker code opens owner web pages, then temporary unlock and final unlock actions are handled through owner-facing routes and backend/API mock paths.
 - Recovery operations: unresolved cases can move toward recovery request and recovery result tracking according to the design docs.
 - Coupon/OCR features exist in backend documentation and code and should be checked against current implementation before changing behavior.

--- a/backend/README.md
+++ b/backend/README.md
@@ -14,6 +14,7 @@ API:
 
 - GET / -> ヘルスチェック
 - POST /auth/register, POST /auth/login
+- POST /api/reports
 - GET/POST /bikes, GET/PUT/DELETE /bikes/:id
 - **POST /bikes/ocr/recognize** -> OCR（防犯登録番号認識）
 - **POST /owner/markers/:code/unlock-temp** -> 仮解除
@@ -33,6 +34,20 @@ API:
 - **有効期限管理**: クーポンごとに有効期限を設定（デフォルト30日間）
 
 ### API使用例
+
+```bash
+# 放置自転車の通報登録
+curl -X POST http://localhost:3000/api/reports \
+  -H "Content-Type: application/json" \
+  -d '{
+    "imageUrl": "https://example.com/report.jpg",
+    "latitude": 34.7055,
+    "longitude": 135.4983,
+    "markerCode": "ABC123",
+    "identifierText": "OSAKA-1234",
+    "notes": "歩道の端に駐輪"
+  }'
+```
 
 ```bash
 # 1. 仮解除（15分間の猶予期間開始）

--- a/backend/prisma/migrations/20260421095738_add_bicycle_report/migration.sql
+++ b/backend/prisma/migrations/20260421095738_add_bicycle_report/migration.sql
@@ -1,0 +1,18 @@
+-- CreateTable
+CREATE TABLE "BicycleReport" (
+    "id" TEXT NOT NULL,
+    "markerId" TEXT NOT NULL,
+    "imageUrl" TEXT NOT NULL,
+    "latitude" DOUBLE PRECISION NOT NULL,
+    "longitude" DOUBLE PRECISION NOT NULL,
+    "identifierText" TEXT NOT NULL,
+    "status" TEXT NOT NULL DEFAULT 'reported',
+    "notes" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "BicycleReport_pkey" PRIMARY KEY ("id")
+);
+
+-- AddForeignKey
+ALTER TABLE "BicycleReport" ADD CONSTRAINT "BicycleReport_markerId_fkey" FOREIGN KEY ("markerId") REFERENCES "Marker"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -46,8 +46,23 @@ model Marker {
   location    String?
   createdAt   DateTime          @default(now())
   updatedAt   DateTime          @updatedAt
+  reports     BicycleReport[]
   declarations Declaration[]
   coupons     CouponIssuance[]
+}
+
+model BicycleReport {
+  id             String   @id @default(uuid())
+  marker         Marker   @relation(fields: [markerId], references: [id])
+  markerId       String
+  imageUrl       String
+  latitude       Float
+  longitude      Float
+  identifierText String
+  status         String   @default("reported")
+  notes          String?
+  createdAt      DateTime @default(now())
+  updatedAt      DateTime @updatedAt
 }
 
 model Declaration {

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -4,6 +4,7 @@ import type { PrismaClient } from '@prisma/client';
 import authRoutes from './routes/auth';
 import bikeRoutes from './routes/bikes';
 import ownerRoutes from './routes/owner';
+import reportRoutes from './routes/reports';
 import { sendError, UnauthorizedError } from './lib/errors';
 import { AuthService } from './services/authService';
 import type { OCRService } from './services/ocrService';
@@ -50,6 +51,7 @@ export function buildServer({ prisma, ocrService, now }: BuildServerOptions = {}
   });
 
   server.register(authRoutes, { prefix: '/auth' });
+  server.register(reportRoutes, { prefix: '/api/reports' });
   server.register(bikeRoutes({ ocrService }), { prefix: '/bikes' });
   server.register(ownerRoutes({ now }), { prefix: '/owner' });
 

--- a/backend/src/routes/reports.ts
+++ b/backend/src/routes/reports.ts
@@ -1,0 +1,27 @@
+import type { FastifyPluginAsync } from 'fastify';
+import { sendError } from '../lib/errors';
+import { ReportService } from '../services/reportService';
+
+type CreateReportBody = {
+  imageUrl?: string;
+  latitude?: number;
+  longitude?: number;
+  markerCode?: string;
+  identifierText?: string;
+  notes?: string;
+};
+
+const reportRoutes: FastifyPluginAsync = async (fastify) => {
+  const reportService = new ReportService(fastify.prisma as any);
+
+  fastify.post<{ Body: CreateReportBody }>('/', async (request, reply) => {
+    try {
+      const report = await reportService.createReport(request.body ?? {});
+      return reply.status(201).send(report);
+    } catch (error) {
+      return sendError(reply, fastify.log, error);
+    }
+  });
+};
+
+export default reportRoutes;

--- a/backend/src/services/ocrService.ts
+++ b/backend/src/services/ocrService.ts
@@ -1,4 +1,9 @@
-import { DocumentAnalysisClient, AzureKeyCredential } from '@azure/ai-form-recognizer';
+import {
+  DocumentAnalysisClient,
+  AzureKeyCredential,
+  type AnalyzeResult,
+  type AnalyzedDocument,
+} from '@azure/ai-form-recognizer';
 import { readFileSync } from 'fs';
 import { resolve } from 'path';
 
@@ -38,8 +43,22 @@ class AzureDocumentAnalyzer implements DocumentAnalyzer {
 
   async analyzeDocument(buffer: Buffer): Promise<OCRAnalysis> {
     const poller = await this.client.beginAnalyzeDocument('prebuilt-read', buffer);
-    return poller.pollUntilDone();
+    const result = await poller.pollUntilDone();
+    return normalizeAnalysis(result);
   }
+}
+
+function normalizeAnalysis(result: AnalyzeResult<AnalyzedDocument>): OCRAnalysis {
+  return {
+    content: result.content ?? '',
+    pages: result.pages?.map((page) => ({
+      lines: page.lines?.map((line) => ({
+        words: Array.from(line.words?.() ?? []).map((word) => ({
+          confidence: word.confidence,
+        })),
+      })),
+    })),
+  };
 }
 
 export function extractRegistrationNumber(text: string): string | null {

--- a/backend/src/services/reportService.ts
+++ b/backend/src/services/reportService.ts
@@ -20,8 +20,11 @@ type ReportRecord = {
 
 type ReportPrisma = {
   marker: {
-    findUnique(args: { where: { code?: string; id?: string } }): Promise<MarkerRecord | null>;
-    create(args: { data: { code: string; location?: string | null } }): Promise<MarkerRecord>;
+    upsert(args: {
+      where: { code: string };
+      update: { location?: string | null };
+      create: { code: string; location?: string | null };
+    }): Promise<MarkerRecord>;
   };
   bicycleReport: {
     create(args: {
@@ -81,16 +84,10 @@ export class ReportService {
   }
 
   private async getOrCreateMarker(code: string) {
-    const existing = await this.prisma.marker.findUnique({
+    return this.prisma.marker.upsert({
       where: { code },
-    });
-
-    if (existing) {
-      return existing;
-    }
-
-    return this.prisma.marker.create({
-      data: { code },
+      update: {},
+      create: { code },
     });
   }
 }

--- a/backend/src/services/reportService.ts
+++ b/backend/src/services/reportService.ts
@@ -1,0 +1,96 @@
+import { BadRequestError } from '../lib/errors';
+
+type MarkerRecord = {
+  id: string;
+  code: string;
+};
+
+type ReportRecord = {
+  id: string;
+  markerId: string;
+  imageUrl: string;
+  latitude: number;
+  longitude: number;
+  identifierText: string;
+  status: string;
+  notes: string | null;
+  createdAt: Date;
+  updatedAt: Date;
+};
+
+type ReportPrisma = {
+  marker: {
+    findUnique(args: { where: { code?: string; id?: string } }): Promise<MarkerRecord | null>;
+    create(args: { data: { code: string; location?: string | null } }): Promise<MarkerRecord>;
+  };
+  bicycleReport: {
+    create(args: {
+      data: {
+        markerId: string;
+        imageUrl: string;
+        latitude: number;
+        longitude: number;
+        identifierText: string;
+        status: string;
+        notes?: string | null;
+      };
+    }): Promise<ReportRecord>;
+  };
+};
+
+export class ReportService {
+  constructor(private readonly prisma: ReportPrisma) {}
+
+  async createReport(input: {
+    imageUrl?: string;
+    latitude?: number;
+    longitude?: number;
+    markerCode?: string;
+    identifierText?: string;
+    notes?: string | null;
+  }) {
+    if (!input.imageUrl) {
+      throw new BadRequestError('imageUrl required');
+    }
+
+    if (typeof input.latitude !== 'number' || typeof input.longitude !== 'number') {
+      throw new BadRequestError('latitude and longitude must be numbers');
+    }
+
+    if (!input.markerCode) {
+      throw new BadRequestError('markerCode required');
+    }
+
+    if (!input.identifierText) {
+      throw new BadRequestError('identifierText required');
+    }
+
+    const marker = await this.getOrCreateMarker(input.markerCode);
+
+    return this.prisma.bicycleReport.create({
+      data: {
+        markerId: marker.id,
+        imageUrl: input.imageUrl,
+        latitude: input.latitude,
+        longitude: input.longitude,
+        identifierText: input.identifierText,
+        status: 'reported',
+        notes: input.notes ?? null,
+      },
+    });
+  }
+
+  private async getOrCreateMarker(code: string) {
+    const existing = await this.prisma.marker.findUnique({
+      where: { code },
+    });
+
+    if (existing) {
+      return existing;
+    }
+
+    return this.prisma.marker.create({
+      data: { code },
+    });
+  }
+}

--- a/backend/test/helpers/mockPrisma.ts
+++ b/backend/test/helpers/mockPrisma.ts
@@ -241,6 +241,31 @@ export function createMockPrisma() {
         markers.set(record.id, record);
         return record;
       },
+      upsert: async ({
+        where,
+        create,
+      }: {
+        where: { code: string };
+        update: { location?: string | null };
+        create: { code: string; location?: string | null };
+      }) => {
+        const existing = Array.from(markers.values()).find((entry) => entry.code === where.code) ?? null;
+        if (existing) {
+          return existing;
+        }
+
+        counters.marker += 1;
+        const now = new Date();
+        const record: MarkerRecord = {
+          id: `m-${counters.marker}`,
+          code: create.code,
+          location: create.location ?? null,
+          createdAt: now,
+          updatedAt: now,
+        };
+        markers.set(record.id, record);
+        return record;
+      },
     },
     bicycleReport: {
       create: async ({

--- a/backend/test/helpers/mockPrisma.ts
+++ b/backend/test/helpers/mockPrisma.ts
@@ -38,6 +38,19 @@ type DeclarationRecord = {
   updatedAt: Date;
 };
 
+type BicycleReportRecord = {
+  id: string;
+  markerId: string;
+  imageUrl: string;
+  latitude: number;
+  longitude: number;
+  identifierText: string;
+  status: string;
+  notes: string | null;
+  createdAt: Date;
+  updatedAt: Date;
+};
+
 type CouponRecord = {
   id: string;
   name: string;
@@ -87,6 +100,7 @@ export function createMockPrisma() {
   const users = new Map<string, UserRecord>();
   const bikes = new Map<string, BikeRecord>();
   const markers = new Map<string, MarkerRecord>();
+  const reports = new Map<string, BicycleReportRecord>();
   const declarations = new Map<string, DeclarationRecord>();
   const coupons = new Map<string, CouponRecord>();
   const couponIssuances = new Map<string, CouponIssuanceRecord>();
@@ -95,6 +109,7 @@ export function createMockPrisma() {
     user: 0,
     bike: 0,
     marker: 0,
+    report: 0,
     declaration: 0,
     coupon: 0,
     issuance: 0,
@@ -224,6 +239,38 @@ export function createMockPrisma() {
           updatedAt: now,
         };
         markers.set(record.id, record);
+        return record;
+      },
+    },
+    bicycleReport: {
+      create: async ({
+        data,
+      }: {
+        data: {
+          markerId: string;
+          imageUrl: string;
+          latitude: number;
+          longitude: number;
+          identifierText: string;
+          status: string;
+          notes?: string | null;
+        };
+      }) => {
+        counters.report += 1;
+        const now = new Date();
+        const record: BicycleReportRecord = {
+          id: `r-${counters.report}`,
+          markerId: data.markerId,
+          imageUrl: data.imageUrl,
+          latitude: data.latitude,
+          longitude: data.longitude,
+          identifierText: data.identifierText,
+          status: data.status,
+          notes: data.notes ?? null,
+          createdAt: now,
+          updatedAt: now,
+        };
+        reports.set(record.id, record);
         return record;
       },
     },
@@ -420,6 +467,7 @@ export function createMockPrisma() {
       users,
       bikes,
       markers,
+      reports,
       declarations,
       coupons,
       couponIssuances,

--- a/backend/test/reports.spec.ts
+++ b/backend/test/reports.spec.ts
@@ -1,0 +1,141 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { buildServer } from '../src/app';
+import { createMockPrisma } from './helpers/mockPrisma';
+
+describe('reports', () => {
+  let server: any;
+  let prismaBundle: ReturnType<typeof createMockPrisma>;
+
+  beforeAll(() => {
+    prismaBundle = createMockPrisma();
+    server = buildServer({
+      prisma: prismaBundle.prisma as any,
+    });
+  });
+
+  afterAll(async () => {
+    await server.close();
+  });
+
+  it('creates a report and creates a marker when markerCode is new', async () => {
+    const response = await server.inject({
+      method: 'POST',
+      url: '/api/reports',
+      payload: {
+        imageUrl: 'https://example.com/report-1.jpg',
+        latitude: 34.7055,
+        longitude: 135.4983,
+        markerCode: 'NEW-MARKER-001',
+        identifierText: 'OSAKA-1234',
+        notes: '歩道の端に駐輪',
+      },
+    });
+
+    expect(response.statusCode).toBe(201);
+    expect(JSON.parse(response.payload)).toMatchObject({
+      markerId: 'm-1',
+      imageUrl: 'https://example.com/report-1.jpg',
+      latitude: 34.7055,
+      longitude: 135.4983,
+      identifierText: 'OSAKA-1234',
+      status: 'reported',
+      notes: '歩道の端に駐輪',
+    });
+    expect(prismaBundle.state.markers.size).toBe(1);
+    expect(prismaBundle.state.reports.size).toBe(1);
+  });
+
+  it('creates a report for an existing marker', async () => {
+    await prismaBundle.prisma.marker.create({
+      data: {
+        code: 'EXISTING-MARKER-001',
+      },
+    });
+
+    const response = await server.inject({
+      method: 'POST',
+      url: '/api/reports',
+      payload: {
+        imageUrl: 'https://example.com/report-2.jpg',
+        latitude: 34.70,
+        longitude: 135.49,
+        markerCode: 'EXISTING-MARKER-001',
+        identifierText: 'KITA-9999',
+      },
+    });
+
+    expect(response.statusCode).toBe(201);
+    expect(JSON.parse(response.payload)).toMatchObject({
+      markerId: 'm-2',
+      status: 'reported',
+      notes: null,
+    });
+    expect(prismaBundle.state.markers.size).toBe(2);
+    expect(prismaBundle.state.reports.size).toBe(2);
+  });
+
+  it('rejects when imageUrl is missing', async () => {
+    const response = await server.inject({
+      method: 'POST',
+      url: '/api/reports',
+      payload: {
+        latitude: 34.7055,
+        longitude: 135.4983,
+        markerCode: 'INVALID-001',
+        identifierText: 'OSAKA-0001',
+      },
+    });
+
+    expect(response.statusCode).toBe(400);
+    expect(JSON.parse(response.payload)).toEqual({ error: 'imageUrl required' });
+  });
+
+  it('rejects when latitude or longitude is invalid', async () => {
+    const response = await server.inject({
+      method: 'POST',
+      url: '/api/reports',
+      payload: {
+        imageUrl: 'https://example.com/report-invalid.jpg',
+        latitude: '34.7055',
+        longitude: 135.4983,
+        markerCode: 'INVALID-002',
+        identifierText: 'OSAKA-0002',
+      },
+    });
+
+    expect(response.statusCode).toBe(400);
+    expect(JSON.parse(response.payload)).toEqual({ error: 'latitude and longitude must be numbers' });
+  });
+
+  it('rejects when markerCode is missing', async () => {
+    const response = await server.inject({
+      method: 'POST',
+      url: '/api/reports',
+      payload: {
+        imageUrl: 'https://example.com/report-invalid.jpg',
+        latitude: 34.7055,
+        longitude: 135.4983,
+        identifierText: 'OSAKA-0003',
+      },
+    });
+
+    expect(response.statusCode).toBe(400);
+    expect(JSON.parse(response.payload)).toEqual({ error: 'markerCode required' });
+  });
+
+  it('rejects when identifierText is missing', async () => {
+    const response = await server.inject({
+      method: 'POST',
+      url: '/api/reports',
+      payload: {
+        imageUrl: 'https://example.com/report-invalid.jpg',
+        latitude: 34.7055,
+        longitude: 135.4983,
+        markerCode: 'INVALID-003',
+      },
+    });
+
+    expect(response.statusCode).toBe(400);
+    expect(JSON.parse(response.payload)).toEqual({ error: 'identifierText required' });
+  });
+});

--- a/docs/api-spec.md
+++ b/docs/api-spec.md
@@ -37,9 +37,14 @@
   - `imageUrl`: string
   - `latitude`: number
   - `longitude`: number
-  - `markerId`?: string
+  - `markerCode`: string
+  - `identifierText`: string
   - `notes`?: string
 - レスポンス: 作成した `report` オブジェクト
+- 実装方針:
+  - `markerCode` は必須
+  - 該当マーカーが存在しない場合は backend 側で新規作成して紐づける
+  - 初期 `status` は `reported`
 
 ### POST /api/reports/validate（将来構想）
 

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -32,11 +32,11 @@
 
 - `id` (UUID, PK)
 - `marker_id` (FK -> Marker)
-- `reporter_id` (FK -> User)
 - `image_url` (string)
 - `latitude`, `longitude` (decimal)
-- `ocr_text` (text)
+- `identifier_text` (text)
 - `status` (enum: reported | temporary | resolved | collection_requested | collected | not_found_on_collection)
+- `notes` (text, nullable)
 - `created_at`, `updated_at`
 
 ## Declaration（移動宣言）

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -192,7 +192,7 @@ components:
           type: string
     ReportCreate:
       type: object
-      required: [imageUrl, latitude, longitude]
+      required: [imageUrl, latitude, longitude, markerCode, identifierText]
       properties:
         imageUrl:
           type: string
@@ -200,7 +200,7 @@ components:
           type: number
         longitude:
           type: number
-        markerId:
+        markerCode:
           type: string
         identifierText:
           type: string
@@ -223,6 +223,9 @@ components:
           type: string
         status:
           $ref: "#/components/schemas/ReportStatus"
+        notes:
+          type: string
+          nullable: true
         createdAt:
           type: string
           format: date-time


### PR DESCRIPTION
## 概要
- `POST /api/reports` を追加し、通報登録時に `markerCode` からマーカーを解決または新規作成するようにしました
- Prisma に `BicycleReport` モデルとマイグレーションを追加しました
- 通報登録の Vitest と API/データモデル関連ドキュメントを更新しました
- 既存の `ocrService` で Azure SDK の戻り値型を内部形式へ正規化し、backend の build が通るようにしました

## 変更内容
- `backend/src/routes/reports.ts` と `backend/src/services/reportService.ts` を追加
- `backend/src/app.ts` に `/api/reports` ルートを登録
- `backend/test/helpers/mockPrisma.ts` を拡張し、`backend/test/reports.spec.ts` を追加
- `backend/prisma/schema.prisma` とマイグレーションに `BicycleReport` を追加
- `backend/src/services/ocrService.ts` で `pollUntilDone()` の結果を内部の `OCRAnalysis` 形式へ正規化
- `docs/api-spec.md` `docs/openapi.yaml` `docs/data-model.md` `ARCHITECTURE.md` `backend/README.md` を実装内容に同期

## 確認状況
- 差分確認: 実施
- `cd backend && npm test -- reports.spec.ts`: 実施済み（6 tests passed）
- `cd backend && npm test`: 実施済み（36 tests passed）
- `cd backend && npm run build`: 実施済み（成功）