### PR TITLE
警告内容参照APIを実装する

### DIFF
--- a/backend/src/routes/owner.ts
+++ b/backend/src/routes/owner.ts
@@ -29,6 +29,15 @@ export default function createOwnerRoutes(options: { now?: () => Date } = {}): F
       options.now
     );
 
+    fastify.get<{ Params: MarkerParams }>('/markers/:code', async (request, reply) => {
+      try {
+        const response = await ownerUnlockService.getMarkerByCode(request.params.code);
+        return reply.send(response);
+      } catch (error) {
+        return sendError(reply, fastify.log, error);
+      }
+    });
+
     fastify.get<{ Params: MarkerParams }>('/markers/:code/coupons', async (request, reply) => {
       try {
         const response = await ownerUnlockService.getCouponsByMarkerCode(request.params.code);

--- a/backend/src/services/ownerUnlockService.ts
+++ b/backend/src/services/ownerUnlockService.ts
@@ -6,19 +6,42 @@ type MarkerRecord = {
   code: string;
 };
 
+type BicycleReportRecord = {
+  id: string;
+  markerId: string;
+  imageUrl: string;
+  latitude: number;
+  longitude: number;
+  identifierText: string;
+  status: string;
+  notes: string | null;
+  createdAt: Date;
+  updatedAt: Date;
+};
+
 type DeclarationRecord = {
   id: string;
   markerId: string;
   declaredAt: Date;
   eligibleFinalAt: Date;
   expiresAt: Date;
+  finalizedAt: Date | null;
   status: string;
+  notes: string | null;
+  createdAt: Date;
+  updatedAt: Date;
 };
 
 type OwnerPrisma = {
   marker: {
     findUnique(args: { where: { code?: string; id?: string } }): Promise<MarkerRecord | null>;
     create(args: { data: { code: string } }): Promise<MarkerRecord>;
+  };
+  bicycleReport: {
+    findFirst(args: {
+      where: { markerId: string };
+      orderBy: { createdAt: 'asc' | 'desc' };
+    }): Promise<BicycleReportRecord | null>;
   };
   declaration: {
     findFirst(args: {
@@ -48,6 +71,35 @@ export class OwnerUnlockService {
     private readonly couponService: CouponService,
     private readonly now: () => Date = () => new Date()
   ) {}
+
+  async getMarkerByCode(code: string) {
+    const marker = await this.prisma.marker.findUnique({
+      where: { code },
+    });
+
+    if (!marker) {
+      throw new NotFoundError('Marker not found');
+    }
+
+    const [report, declaration] = await Promise.all([
+      this.prisma.bicycleReport.findFirst({
+        where: { markerId: marker.id },
+        orderBy: { createdAt: 'desc' },
+      }),
+      this.prisma.declaration.findFirst({
+        where: { markerId: marker.id },
+        orderBy: { declaredAt: 'desc' },
+      }),
+    ]);
+
+    return {
+      marker: {
+        code: marker.code,
+      },
+      report,
+      declaration,
+    };
+  }
 
   async getCouponsByMarkerCode(code: string) {
     const marker = await this.prisma.marker.findUnique({

--- a/backend/test/helpers/mockPrisma.ts
+++ b/backend/test/helpers/mockPrisma.ts
@@ -268,6 +268,21 @@ export function createMockPrisma() {
       },
     },
     bicycleReport: {
+      findFirst: async ({
+        where,
+        orderBy,
+      }: {
+        where: { markerId: string };
+        orderBy: { createdAt: 'asc' | 'desc' };
+      }) => {
+        const filtered = Array.from(reports.values()).filter((entry) => entry.markerId === where.markerId);
+
+        if (orderBy.createdAt === 'asc') {
+          return [...filtered].sort((left, right) => left.createdAt.getTime() - right.createdAt.getTime())[0] ?? null;
+        }
+
+        return sortByDateDesc(filtered, (entry) => entry.createdAt)[0] ?? null;
+      },
       findMany: async ({
         where,
         orderBy,

--- a/backend/test/owner.spec.ts
+++ b/backend/test/owner.spec.ts
@@ -20,6 +20,155 @@ describe('owner', () => {
     await server.close();
   });
 
+  it('returns marker details with the latest report and declaration', async () => {
+    const marker = await prismaBundle.prisma.marker.create({
+      data: { code: 'DETAIL-001' },
+    });
+
+    await prismaBundle.prisma.bicycleReport.create({
+      data: {
+        markerId: marker.id,
+        imageUrl: 'https://example.com/old.jpg',
+        latitude: 34.7001,
+        longitude: 135.5001,
+        identifierText: 'OLD-TEXT',
+        status: 'reported',
+      },
+    });
+
+    const latestReport = await prismaBundle.prisma.bicycleReport.create({
+      data: {
+        markerId: marker.id,
+        imageUrl: 'https://example.com/latest.jpg',
+        latitude: 34.7002,
+        longitude: 135.5002,
+        identifierText: 'LATEST-TEXT',
+        status: 'temporary',
+      },
+    });
+    const oldReport = prismaBundle.state.reports.get('r-1');
+    if (oldReport) {
+      oldReport.createdAt = new Date('2026-04-20T08:30:00.000Z');
+      oldReport.updatedAt = new Date('2026-04-20T08:30:00.000Z');
+      prismaBundle.state.reports.set(oldReport.id, oldReport);
+    }
+    const latestReportRecord = prismaBundle.state.reports.get(latestReport.id);
+    if (latestReportRecord) {
+      latestReportRecord.createdAt = new Date('2026-04-20T09:30:00.000Z');
+      latestReportRecord.updatedAt = new Date('2026-04-20T09:30:00.000Z');
+      prismaBundle.state.reports.set(latestReportRecord.id, latestReportRecord);
+    }
+
+    await prismaBundle.prisma.declaration.create({
+      data: {
+        markerId: marker.id,
+        declaredAt: new Date('2026-04-20T08:00:00.000Z'),
+        eligibleFinalAt: new Date('2026-04-20T08:15:00.000Z'),
+        expiresAt: new Date('2026-04-21T08:00:00.000Z'),
+        status: 'resolved',
+      },
+    });
+
+    const latestDeclaration = await prismaBundle.prisma.declaration.create({
+      data: {
+        markerId: marker.id,
+        declaredAt: new Date('2026-04-20T09:00:00.000Z'),
+        eligibleFinalAt: new Date('2026-04-20T09:15:00.000Z'),
+        expiresAt: new Date('2026-04-21T09:00:00.000Z'),
+        status: 'temporary',
+      },
+    });
+
+    const response = await server.inject({
+      method: 'GET',
+      url: '/owner/markers/DETAIL-001',
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(JSON.parse(response.payload)).toEqual({
+      marker: {
+        code: 'DETAIL-001',
+      },
+      report: {
+        ...latestReport,
+        createdAt: '2026-04-20T09:30:00.000Z',
+        updatedAt: '2026-04-20T09:30:00.000Z',
+      },
+      declaration: {
+        ...latestDeclaration,
+        declaredAt: latestDeclaration.declaredAt.toISOString(),
+        eligibleFinalAt: latestDeclaration.eligibleFinalAt.toISOString(),
+        expiresAt: latestDeclaration.expiresAt.toISOString(),
+        finalizedAt: latestDeclaration.finalizedAt,
+        createdAt: latestDeclaration.createdAt.toISOString(),
+        updatedAt: latestDeclaration.updatedAt.toISOString(),
+      },
+    });
+  });
+
+  it('returns nulls when marker has no report or declaration', async () => {
+    await prismaBundle.prisma.marker.create({
+      data: { code: 'DETAIL-EMPTY' },
+    });
+
+    const response = await server.inject({
+      method: 'GET',
+      url: '/owner/markers/DETAIL-EMPTY',
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(JSON.parse(response.payload)).toEqual({
+      marker: { code: 'DETAIL-EMPTY' },
+      report: null,
+      declaration: null,
+    });
+  });
+
+  it('returns null declaration when marker has only a report', async () => {
+    const marker = await prismaBundle.prisma.marker.create({
+      data: { code: 'DETAIL-REPORT-ONLY' },
+    });
+
+    const report = await prismaBundle.prisma.bicycleReport.create({
+      data: {
+        markerId: marker.id,
+        imageUrl: 'https://example.com/report-only.jpg',
+        latitude: 34.701,
+        longitude: 135.501,
+        identifierText: 'REPORT-ONLY',
+        status: 'reported',
+      },
+    });
+
+    const response = await server.inject({
+      method: 'GET',
+      url: '/owner/markers/DETAIL-REPORT-ONLY',
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(JSON.parse(response.payload)).toEqual({
+      marker: { code: 'DETAIL-REPORT-ONLY' },
+      report: {
+        ...report,
+        createdAt: report.createdAt.toISOString(),
+        updatedAt: report.updatedAt.toISOString(),
+      },
+      declaration: null,
+    });
+  });
+
+  it('returns 404 when marker code does not exist', async () => {
+    const response = await server.inject({
+      method: 'GET',
+      url: '/owner/markers/UNKNOWN-CODE',
+    });
+
+    expect(response.statusCode).toBe(404);
+    expect(JSON.parse(response.payload)).toEqual({
+      error: 'Marker not found',
+    });
+  });
+
   it('creates a temporary unlock declaration', async () => {
     const response = await server.inject({
       method: 'POST',

--- a/docs/api-spec.md
+++ b/docs/api-spec.md
@@ -144,6 +144,8 @@
 ### GET /api/owner/markers/:code
 
 - 説明: QR からアクセスした持ち主に、対象マーカーの警告内容、通報状態、仮解除情報を返す
+- 挙動: `marker.code` と、該当 marker に紐づく最新 `BicycleReport`・最新 `Declaration` を返す。`report` と `declaration` は存在しない場合 `null`
+- エラー: marker が存在しない場合は `404` で `{ "error": "Marker not found" }`
 
 ### GET /api/owner/markers/:code/coupons（実装済み・将来拡張）
 

--- a/docs/openapi-owner.yaml
+++ b/docs/openapi-owner.yaml
@@ -20,6 +20,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/OwnerMarkerResponse'
+        '404':
+          description: Marker not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
   /owner/markers/{code}/unlock-temp:
     post:
       summary: Create temporary unlock (仮解除)
@@ -73,27 +79,75 @@ components:
     OwnerMarkerResponse:
       type: object
       properties:
-        status:
-          type: string
-          example: ok
-        data:
+        marker:
           type: object
           properties:
-            marker:
-              type: object
-              properties:
-                code: { type: string }
-                location:
-                  type: object
-                  properties:
-                    lat: { type: number }
-                    lng: { type: number }
-            report:
-              type: object
-              nullable: true
-            declaration:
-              type: object
-              nullable: true
+            code:
+              type: string
+        report:
+          allOf:
+            - $ref: '#/components/schemas/BicycleReport'
+          nullable: true
+        declaration:
+          $ref: '#/components/schemas/Declaration'
+    BicycleReport:
+      type: object
+      properties:
+        id:
+          type: string
+        markerId:
+          type: string
+        imageUrl:
+          type: string
+        latitude:
+          type: number
+        longitude:
+          type: number
+        identifierText:
+          type: string
+        status:
+          type: string
+        notes:
+          type: string
+          nullable: true
+        createdAt:
+          type: string
+          format: date-time
+        updatedAt:
+          type: string
+          format: date-time
+    Declaration:
+      type: object
+      properties:
+        id:
+          type: string
+        markerId:
+          type: string
+        declaredAt:
+          type: string
+          format: date-time
+        eligibleFinalAt:
+          type: string
+          format: date-time
+        expiresAt:
+          type: string
+          format: date-time
+        finalizedAt:
+          type: string
+          format: date-time
+          nullable: true
+        status:
+          type: string
+        notes:
+          type: string
+          nullable: true
+        createdAt:
+          type: string
+          format: date-time
+        updatedAt:
+          type: string
+          format: date-time
+      nullable: true
     TemporaryUnlockResponse:
       type: object
       properties:
@@ -149,3 +203,8 @@ components:
         ownerEmail:
           type: string
           format: email
+    ErrorResponse:
+      type: object
+      properties:
+        error:
+          type: string

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -117,6 +117,12 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/OwnerMarkerResponse"
+        "404":
+          description: Marker not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
   /api/owner/markers/{code}/unlock-temp:
     post:
       summary: 持ち主による仮解除
@@ -255,9 +261,48 @@ components:
             code:
               type: string
         report:
-          $ref: "#/components/schemas/BicycleReport"
+          allOf:
+            - $ref: "#/components/schemas/BicycleReport"
+          nullable: true
         declaration:
-          type: object
+          $ref: "#/components/schemas/Declaration"
+    Declaration:
+      type: object
+      properties:
+        id:
+          type: string
+        markerId:
+          type: string
+        declaredAt:
+          type: string
+          format: date-time
+        eligibleFinalAt:
+          type: string
+          format: date-time
+        expiresAt:
+          type: string
+          format: date-time
+        finalizedAt:
+          type: string
+          format: date-time
+          nullable: true
+        status:
+          type: string
+        notes:
+          type: string
+          nullable: true
+        createdAt:
+          type: string
+          format: date-time
+        updatedAt:
+          type: string
+          format: date-time
+      nullable: true
+    ErrorResponse:
+      type: object
+      properties:
+        error:
+          type: string
           nullable: true
     UnlockTempBody:
       type: object

--- a/docs/owner-api.md
+++ b/docs/owner-api.md
@@ -39,20 +39,46 @@ QRコードでアクセスする持ち主向けの簡易Webフロー向けAPI仕
 
 ### GET /api/owner/markers/{code}
 
-- 説明: 指定 `code` の最新 `BicycleReport`（あれば）と現在の `declaration` を返す
-- ステータスコード: 200 OK
+- 説明: 指定 `code` の `Marker` に紐づく最新 `BicycleReport`（あれば）と最新 `declaration`（あれば）を返す
+- ステータスコード: 200 OK, 404 Not Found
 - レスポンス例:
 
 ```json
 {
   "marker": { "code": "ABC123" },
   "report": {
-    "id": "r-ABC123",
+    "id": "r-1",
+    "markerId": "m-1",
+    "imageUrl": "https://example.com/report.jpg",
+    "latitude": 34.701,
+    "longitude": 135.502,
+    "identifierText": "OSAKA-123456",
     "status": "reported",
-    "imageUrl": "",
-    "ocr_text": ""
+    "notes": null,
+    "createdAt": "2026-01-19T11:40:00.000Z",
+    "updatedAt": "2026-01-19T11:40:00.000Z"
   },
-  "declaration": null
+  "declaration": {
+    "id": "d-1",
+    "markerId": "m-1",
+    "declaredAt": "2026-01-19T12:00:00.000Z",
+    "eligibleFinalAt": "2026-01-19T12:15:00.000Z",
+    "expiresAt": "2026-01-20T12:00:00.000Z",
+    "finalizedAt": null,
+    "status": "temporary",
+    "notes": null,
+    "createdAt": "2026-01-19T12:00:00.000Z",
+    "updatedAt": "2026-01-19T12:00:00.000Z"
+  }
+}
+```
+
+- `report` と `declaration` は存在しない場合に `null` を返す
+- 未知の `code` の場合は以下を返す
+
+```json
+{
+  "error": "Marker not found"
 }
 ```
 
@@ -179,7 +205,7 @@ QRコードでアクセスする持ち主向けの簡易Webフロー向けAPI仕
 
 ## 受入基準
 
-- `GET /api/owner/markers/{code}` が該当レポート（画像・OCRテキスト含む）を表示する
+- `GET /api/owner/markers/{code}` が該当レポート（画像・識別テキスト含む）と最新 declaration を返す
 - `POST /api/owner/markers/{code}/unlock-temp` で `declaredAt`, `eligibleFinalAt`, `expiresAt` が返る
 - 仮解除後、同一マーカーQRコードをカメラで再スキャンすることで本解除が実行される
 - `unlock-final` は `eligibleFinalAt` 到達前は拒否、到達後は `resolved` になる


### PR DESCRIPTION
## 概要
- `GET /owner/markers/:code` を追加し、marker に紐づく最新の通報内容と宣言情報を返すようにしました
- marker 未存在時は `404` を返すようにし、owner API の契約を明確化しました
- backend テストと owner API 関連ドキュメントを実装内容に合わせて更新しました

## 変更内容
- `OwnerUnlockService` に marker 詳細参照処理を追加
- owner route に `GET /markers/:code` を追加
- Prisma mock と owner backend テストを拡張
- `docs/owner-api.md` `docs/api-spec.md` `docs/openapi.yaml` `docs/openapi-owner.yaml` を更新

## 確認内容
- `cd backend && npm test`
- `cd backend && npm run build`

Closes #27