### PR TITLE
回収依頼APIを実装

### DIFF
--- a/backend/prisma/migrations/20260427113000_add_collection_request/migration.sql
+++ b/backend/prisma/migrations/20260427113000_add_collection_request/migration.sql
@@ -1,0 +1,18 @@
+-- CreateTable
+CREATE TABLE "CollectionRequest" (
+    "id" TEXT NOT NULL,
+    "reportId" TEXT NOT NULL,
+    "requestedBy" TEXT,
+    "requestedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "result" TEXT NOT NULL DEFAULT 'pending',
+    "resultRecordedBy" TEXT,
+    "resultRecordedAt" TIMESTAMP(3),
+    "notes" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "CollectionRequest_pkey" PRIMARY KEY ("id")
+);
+
+-- AddForeignKey
+ALTER TABLE "CollectionRequest" ADD CONSTRAINT "CollectionRequest_reportId_fkey" FOREIGN KEY ("reportId") REFERENCES "BicycleReport"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -52,17 +52,32 @@ model Marker {
 }
 
 model BicycleReport {
-  id             String   @id @default(uuid())
-  marker         Marker   @relation(fields: [markerId], references: [id])
-  markerId       String
-  imageUrl       String
-  latitude       Float
-  longitude      Float
-  identifierText String
-  status         String   @default("reported")
-  notes          String?
-  createdAt      DateTime @default(now())
-  updatedAt      DateTime @updatedAt
+  id                 String              @id @default(uuid())
+  marker             Marker              @relation(fields: [markerId], references: [id])
+  markerId           String
+  imageUrl           String
+  latitude           Float
+  longitude          Float
+  identifierText     String
+  status             String              @default("reported")
+  notes              String?
+  createdAt          DateTime            @default(now())
+  updatedAt          DateTime            @updatedAt
+  collectionRequests CollectionRequest[]
+}
+
+model CollectionRequest {
+  id               String        @id @default(uuid())
+  report           BicycleReport @relation(fields: [reportId], references: [id])
+  reportId         String
+  requestedBy      String?
+  requestedAt      DateTime      @default(now())
+  result           String        @default("pending") // pending, collected, not_found_on_collection
+  resultRecordedBy String?
+  resultRecordedAt DateTime?
+  notes            String?
+  createdAt        DateTime      @default(now())
+  updatedAt        DateTime      @updatedAt
 }
 
 model Declaration {

--- a/backend/src/routes/reports.ts
+++ b/backend/src/routes/reports.ts
@@ -11,6 +11,11 @@ type CreateReportBody = {
   notes?: string;
 };
 
+type CollectionRequestBody = {
+  notes?: string;
+  requestedBy?: string;
+};
+
 type ListReportsQuery = {
   status?: string;
 };
@@ -48,6 +53,18 @@ const reportRoutes: FastifyPluginAsync = async (fastify) => {
       return sendError(reply, fastify.log, error);
     }
   });
+
+  fastify.post<{ Params: ReportParams; Body: CollectionRequestBody }>(
+    '/:id/collection-request',
+    async (request, reply) => {
+      try {
+        const report = await reportService.requestCollection(request.params.id, request.body ?? {});
+        return reply.send(report);
+      } catch (error) {
+        return sendError(reply, fastify.log, error);
+      }
+    }
+  );
 };
 
 export default reportRoutes;

--- a/backend/src/services/reportService.ts
+++ b/backend/src/services/reportService.ts
@@ -18,14 +18,20 @@ type ReportRecord = {
   updatedAt: Date;
 };
 
-type ReportPrisma = {
-  marker: {
-    upsert(args: {
-      where: { code: string };
-      update: { location?: string | null };
-      create: { code: string; location?: string | null };
-    }): Promise<MarkerRecord>;
-  };
+type CollectionRequestRecord = {
+  id: string;
+  reportId: string;
+  requestedBy: string | null;
+  requestedAt: Date;
+  result: string;
+  resultRecordedBy: string | null;
+  resultRecordedAt: Date | null;
+  notes: string | null;
+  createdAt: Date;
+  updatedAt: Date;
+};
+
+type ReportTransactionPrisma = {
   bicycleReport: {
     findMany(args: {
       where?: { status?: string };
@@ -45,7 +51,43 @@ type ReportPrisma = {
         notes?: string | null;
       };
     }): Promise<ReportRecord>;
+    update(args: {
+      where: { id: string };
+      data: {
+        status?: string;
+        notes?: string | null;
+      };
+    }): Promise<ReportRecord>;
+    updateMany(args: {
+      where: { id: string; status?: string };
+      data: {
+        status?: string;
+        notes?: string | null;
+      };
+    }): Promise<{ count: number }>;
   };
+  collectionRequest: {
+    create(args: {
+      data: {
+        reportId: string;
+        requestedBy?: string | null;
+        requestedAt: Date;
+        result: string;
+        notes?: string | null;
+      };
+    }): Promise<CollectionRequestRecord>;
+  };
+};
+
+type ReportPrisma = ReportTransactionPrisma & {
+  marker: {
+    upsert(args: {
+      where: { code: string };
+      update: { location?: string | null };
+      create: { code: string; location?: string | null };
+    }): Promise<MarkerRecord>;
+  };
+  $transaction<T>(fn: (tx: ReportTransactionPrisma) => Promise<T>): Promise<T>;
 };
 
 export class ReportService {
@@ -106,6 +148,58 @@ export class ReportService {
         status: 'reported',
         notes: input.notes ?? null,
       },
+    });
+  }
+
+  async requestCollection(id: string, input: { notes?: string | null; requestedBy?: string | null }) {
+    const report = await this.prisma.bicycleReport.findUnique({
+      where: { id },
+    });
+
+    if (!report) {
+      throw new NotFoundError('report not found');
+    }
+
+    if (report.status !== 'reported') {
+      throw new BadRequestError('report is not eligible for collection request');
+    }
+
+    const requestedAt = new Date();
+
+    return this.prisma.$transaction(async (tx) => {
+      const updateResult = await tx.bicycleReport.updateMany({
+        where: {
+          id: report.id,
+          status: 'reported',
+        },
+        data: {
+          status: 'collection_requested',
+        },
+      });
+
+      if (updateResult.count !== 1) {
+        throw new BadRequestError('report is not eligible for collection request');
+      }
+
+      await tx.collectionRequest.create({
+        data: {
+          reportId: report.id,
+          requestedBy: input.requestedBy ?? null,
+          requestedAt,
+          result: 'pending',
+          notes: input.notes ?? null,
+        },
+      });
+
+      const updatedReport = await tx.bicycleReport.findUnique({
+        where: { id: report.id },
+      });
+
+      if (!updatedReport) {
+        throw new NotFoundError('report not found');
+      }
+
+      return updatedReport;
     });
   }
 

--- a/backend/test/helpers/mockPrisma.ts
+++ b/backend/test/helpers/mockPrisma.ts
@@ -51,6 +51,19 @@ type BicycleReportRecord = {
   updatedAt: Date;
 };
 
+type CollectionRequestRecord = {
+  id: string;
+  reportId: string;
+  requestedBy: string | null;
+  requestedAt: Date;
+  result: string;
+  resultRecordedBy: string | null;
+  resultRecordedAt: Date | null;
+  notes: string | null;
+  createdAt: Date;
+  updatedAt: Date;
+};
+
 type CouponRecord = {
   id: string;
   name: string;
@@ -101,6 +114,7 @@ export function createMockPrisma() {
   const bikes = new Map<string, BikeRecord>();
   const markers = new Map<string, MarkerRecord>();
   const reports = new Map<string, BicycleReportRecord>();
+  const collectionRequests = new Map<string, CollectionRequestRecord>();
   const declarations = new Map<string, DeclarationRecord>();
   const coupons = new Map<string, CouponRecord>();
   const couponIssuances = new Map<string, CouponIssuanceRecord>();
@@ -110,6 +124,7 @@ export function createMockPrisma() {
     bike: 0,
     marker: 0,
     report: 0,
+    collectionRequest: 0,
     declaration: 0,
     coupon: 0,
     issuance: 0,
@@ -339,6 +354,78 @@ export function createMockPrisma() {
         reports.set(record.id, record);
         return record;
       },
+      update: async ({
+        where,
+        data,
+      }: {
+        where: { id: string };
+        data: { status?: string; notes?: string | null };
+      }) => {
+        const existing = reports.get(where.id);
+        if (!existing) {
+          throw new Error('not found');
+        }
+
+        const updated: BicycleReportRecord = {
+          ...existing,
+          status: data.status ?? existing.status,
+          notes: data.notes ?? existing.notes,
+          updatedAt: new Date(),
+        };
+        reports.set(where.id, updated);
+        return updated;
+      },
+      updateMany: async ({
+        where,
+        data,
+      }: {
+        where: { id: string; status?: string };
+        data: { status?: string; notes?: string | null };
+      }) => {
+        const existing = reports.get(where.id);
+        if (!existing || (where.status && existing.status !== where.status)) {
+          return { count: 0 };
+        }
+
+        const updated: BicycleReportRecord = {
+          ...existing,
+          status: data.status ?? existing.status,
+          notes: data.notes ?? existing.notes,
+          updatedAt: new Date(),
+        };
+        reports.set(where.id, updated);
+        return { count: 1 };
+      },
+    },
+    collectionRequest: {
+      create: async ({
+        data,
+      }: {
+        data: {
+          reportId: string;
+          requestedBy?: string | null;
+          requestedAt: Date;
+          result: string;
+          notes?: string | null;
+        };
+      }) => {
+        counters.collectionRequest += 1;
+        const now = new Date();
+        const record: CollectionRequestRecord = {
+          id: `cr-${counters.collectionRequest}`,
+          reportId: data.reportId,
+          requestedBy: data.requestedBy ?? null,
+          requestedAt: data.requestedAt,
+          result: data.result,
+          resultRecordedBy: null,
+          resultRecordedAt: null,
+          notes: data.notes ?? null,
+          createdAt: now,
+          updatedAt: now,
+        };
+        collectionRequests.set(record.id, record);
+        return record;
+      },
     },
     declaration: {
       findFirst: async ({
@@ -525,6 +612,7 @@ export function createMockPrisma() {
         return updated;
       },
     },
+    $transaction: async <T>(fn: (tx: typeof prisma) => Promise<T>) => fn(prisma),
   };
 
   return {
@@ -534,6 +622,7 @@ export function createMockPrisma() {
       bikes,
       markers,
       reports,
+      collectionRequests,
       declarations,
       coupons,
       couponIssuances,

--- a/backend/test/reports.spec.ts
+++ b/backend/test/reports.spec.ts
@@ -1,5 +1,7 @@
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import { buildServer } from '../src/app';
+import { BadRequestError } from '../src/lib/errors';
+import { ReportService } from '../src/services/reportService';
 import { createMockPrisma } from './helpers/mockPrisma';
 
 describe('reports', () => {
@@ -128,6 +130,114 @@ describe('reports', () => {
 
     expect(response.statusCode).toBe(404);
     expect(JSON.parse(response.payload)).toEqual({ error: 'report not found' });
+  });
+
+  it('requests collection for a reported report and stores request history', async () => {
+    const response = await server.inject({
+      method: 'POST',
+      url: '/api/reports/r-2/collection-request',
+      payload: {
+        notes: '歩道上のため回収依頼',
+        requestedBy: '北区役所 管理担当',
+      },
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(JSON.parse(response.payload)).toMatchObject({
+      id: 'r-2',
+      status: 'collection_requested',
+    });
+
+    expect(prismaBundle.state.reports.get('r-2')!.status).toBe('collection_requested');
+    expect(Array.from(prismaBundle.state.collectionRequests.values())).toEqual([
+      expect.objectContaining({
+        reportId: 'r-2',
+        requestedBy: '北区役所 管理担当',
+        result: 'pending',
+        resultRecordedBy: null,
+        resultRecordedAt: null,
+        notes: '歩道上のため回収依頼',
+      }),
+    ]);
+  });
+
+  it('returns 404 when requesting collection for a missing report', async () => {
+    const response = await server.inject({
+      method: 'POST',
+      url: '/api/reports/r-999/collection-request',
+      payload: {
+        requestedBy: '北区役所 管理担当',
+      },
+    });
+
+    expect(response.statusCode).toBe(404);
+    expect(JSON.parse(response.payload)).toEqual({ error: 'report not found' });
+  });
+
+  it('rejects collection request when report is not reported', async () => {
+    for (const status of ['temporary', 'resolved', 'collection_requested']) {
+      const report = await prismaBundle.prisma.bicycleReport.create({
+        data: {
+          markerId: 'm-2',
+          imageUrl: `https://example.com/report-${status}.jpg`,
+          latitude: 34.701,
+          longitude: 135.491,
+          identifierText: `STATUS-${status}`,
+          status,
+        },
+      });
+
+      const response = await server.inject({
+        method: 'POST',
+        url: `/api/reports/${report.id}/collection-request`,
+        payload: {
+          requestedBy: '北区役所 管理担当',
+        },
+      });
+
+      expect(response.statusCode).toBe(400);
+      expect(JSON.parse(response.payload)).toEqual({ error: 'report is not eligible for collection request' });
+      expect(prismaBundle.state.reports.get(report.id)!.status).toBe(status);
+    }
+  });
+
+  it('does not store request history when status changes before transactional update', async () => {
+    const isolatedPrismaBundle = createMockPrisma();
+    const marker = await isolatedPrismaBundle.prisma.marker.create({
+      data: {
+        code: 'RACE-MARKER-001',
+      },
+    });
+    const report = await isolatedPrismaBundle.prisma.bicycleReport.create({
+      data: {
+        markerId: marker.id,
+        imageUrl: 'https://example.com/report-race.jpg',
+        latitude: 34.701,
+        longitude: 135.491,
+        identifierText: 'RACE-0001',
+        status: 'reported',
+      },
+    });
+
+    const originalFindUnique = isolatedPrismaBundle.prisma.bicycleReport.findUnique;
+    isolatedPrismaBundle.prisma.bicycleReport.findUnique = async (args) => {
+      const found = await originalFindUnique(args);
+      if (args.where.id === report.id && found?.status === 'reported') {
+        isolatedPrismaBundle.state.reports.get(report.id)!.status = 'collection_requested';
+      }
+      return found;
+    };
+
+    const reportService = new ReportService(isolatedPrismaBundle.prisma as any);
+
+    await expect(
+      reportService.requestCollection(report.id, {
+        requestedBy: '北区役所 管理担当',
+      })
+    ).rejects.toBeInstanceOf(BadRequestError);
+
+    expect(isolatedPrismaBundle.state.collectionRequests.size).toBe(0);
+    expect(isolatedPrismaBundle.state.reports.get(report.id)!.status).toBe('collection_requested');
   });
 
   it('creates a report for an existing marker', async () => {

--- a/docs/api-spec.md
+++ b/docs/api-spec.md
@@ -91,7 +91,7 @@
 ### POST /api/reports/:id/collection-request
 
 - 説明: 一定時間内に持ち主による解除が行われなかった通報を、管理者が回収依頼対象にする
-- Body: `{ "notes"?: string }`
+- Body: `{ "notes"?: string, "requestedBy"?: string }`
 - 期待挙動:
   - report.status を `collection_requested` に更新する
   - 回収依頼の操作履歴を保存する

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -55,10 +55,10 @@
 
 - `id` (UUID, PK)
 - `report_id` (FK -> BicycleReport)
-- `requested_by` (FK -> User)
+- `requested_by` (string, nullable; 試作品では認証連携なしで行政側の操作主体を任意保存)
 - `requested_at` (timestamp)
 - `result` (enum: pending | collected | not_found_on_collection)
-- `result_recorded_by` (FK -> User, nullable)
+- `result_recorded_by` (string, nullable; 試作品では認証連携なしで任意保存)
 - `result_recorded_at` (timestamp, nullable)
 - `notes` (text, nullable)
 - `created_at`, `updated_at`

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -243,6 +243,8 @@ components:
       properties:
         notes:
           type: string
+        requestedBy:
+          type: string
     CollectionResultBody:
       type: object
       required: [result]

--- a/plan/2026-04-27__issue-30-collection-request.md
+++ b/plan/2026-04-27__issue-30-collection-request.md
@@ -1,0 +1,32 @@
+# Issue 30 回収依頼API
+
+## Goal
+
+- `POST /api/reports/:id/collection-request` を実装し、`reported` の通報を `collection_requested` に更新する。
+- 回収依頼履歴を `CollectionRequest` として保存する。
+
+## Non-goals
+
+- 管理者JWT認証やUser FK連携は今回含めない。
+- 回収結果記録APIは別タスクで扱う。
+
+## Changes
+
+- `CollectionRequest` Prismaモデルとmigrationを追加する。
+- 回収依頼APIは `notes` と任意の `requestedBy` を受け取り、履歴へ保存する。
+- 回収依頼対象は `reported` のみとし、それ以外のstatusは400で拒否する。
+- `docs/api-spec.md`、`docs/openapi.yaml`、`docs/data-model.md` を実装に合わせて更新する。
+
+## Verification
+
+- `TMPDIR=/tmp npm test -- reports.spec.ts`
+- `TMPDIR=/tmp npm test`
+- `npm run build`
+- `DATABASE_URL=postgresql://user:password@localhost:5432/no_houchi npm exec -- prisma validate`
+- `DATABASE_URL=postgresql://user:password@localhost:5432/no_houchi npm run prisma:generate`
+
+## Docs Maintenance
+
+- `AGENTS.md`: コマンドや運用ルール変更なしのため更新不要。
+- `ARCHITECTURE.md`: 既に回収依頼を主要フローとして記載済みのため更新不要。
+- `docs/adr/`: 認証なしの `requestedBy` は試作品向けのIssue限定実装であり、長期アーキテクチャ判断ではないため追加不要。


### PR DESCRIPTION
## 概要
- reported の通報を collection_requested に更新する回収依頼APIを追加
- CollectionRequest モデルとmigrationを追加し、notes/requestedBy付きで依頼履歴を保存
- API仕様、OpenAPI、データモデル、planファイルを更新

## 検証
- TMPDIR=/tmp npm test -- reports.spec.ts
- TMPDIR=/tmp npm test
- npm run build
- DATABASE_URL=postgresql://user:password@localhost:5432/no_houchi npm exec -- prisma validate
- DATABASE_URL=postgresql://user:password@localhost:5432/no_houchi npm run prisma:generate

Closes #30