### PR TITLE
Backendのdotenv読み込みと開発手順を修正

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,5 +1,8 @@
 # Database
-DATABASE_URL=postgresql://postgres:postgres@postgres:5432/no_houchi_dev
+# Host execution (`npm run dev` on your machine) connects through the published port.
+DATABASE_URL=postgresql://postgres:postgres@localhost:5432/no_houchi_dev
+# Docker Compose `app` container execution should use the service name instead:
+# DATABASE_URL=postgresql://postgres:postgres@postgres:5432/no_houchi_dev
 
 # JWT
 JWT_SECRET=change-me

--- a/backend/README.md
+++ b/backend/README.md
@@ -2,13 +2,23 @@
 
 TypeScript + Fastify + Prisma ベースの API サーバーのスキャフォールドです。
 
-セットアップ:
+セットアップ（ホスト上で `npm run dev` する場合）:
 
-1. .env を作成（`cp .env.example .env`）
-2. Docker Compose で起動: `docker-compose up -d`（Postgres を起動）
-3. 依存関係をインストール: `npm install`
+1. 依存関係をインストール: `npm install`
+2. .env を作成: `cp .env.example .env`
+3. Docker Compose で Postgres を起動: `docker-compose up -d`
 4. Prisma 生成/マイグレート: `npm run prisma:generate && npm run prisma:migrate`
 5. 開発サーバー起動: `npm run dev`
+
+`backend/.env.example` の `DATABASE_URL` はホスト実行向けに `localhost` を使います。Docker Compose の `app` コンテナ内から Backend を起動する場合のみ、DB ホスト名を Compose サービス名の `postgres` に変更してください。
+
+DB 接続とマイグレーション状態の確認:
+
+```bash
+npx prisma validate
+npx prisma migrate status
+curl http://localhost:3000/api/reports
+```
 
 API:
 
@@ -134,4 +144,4 @@ curl -X POST http://localhost:3000/bikes/ocr/recognize \
 
 - CI は導入しません。ローカル検証を重視し、[`docs/operations/developer-workflow.md`](../docs/operations/developer-workflow.md) に手順をまとめています。
 - ローカルでのテスト実行: `npm test`（Vitest）
-- 推奨: Docker Compose で Postgres を立ち上げ、`npx prisma generate` / `npx prisma migrate dev` を実行してから `npm run dev` でアプリを起動してください。
+- 推奨: Docker Compose で Postgres を立ち上げ、`npm run prisma:generate` / `npm run prisma:migrate` を実行してから `npm run dev` でアプリを起動してください。

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -1,3 +1,4 @@
+import 'dotenv/config';
 import { buildServer } from './app';
 
 const server = buildServer();

--- a/backend/test/index-env.spec.ts
+++ b/backend/test/index-env.spec.ts
@@ -1,0 +1,14 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+describe('backend entrypoint environment loading', () => {
+  it('preloads dotenv before creating the server', () => {
+    const source = readFileSync(resolve(__dirname, '../src/index.ts'), 'utf8');
+    const firstImport = source
+      .split('\n')
+      .find((line) => line.trim().startsWith('import'));
+
+    expect(firstImport).toBe("import 'dotenv/config';");
+  });
+});

--- a/docs/operations/developer-workflow.md
+++ b/docs/operations/developer-workflow.md
@@ -15,18 +15,29 @@
 cd backend
 npm install
 cp .env.example .env
-# 必要に応じて .env の環境変数を編集（DB接続、JWT_SECRET など）
+# ホスト上で npm run dev する場合、DATABASE_URL のホストは localhost のままにします。
+# Docker Compose の app コンテナ内から起動する場合のみ、DBホストを postgres に変更します。
+# 必要に応じて .env のその他の環境変数を編集（JWT_SECRET など）
 
 # Docker で Postgres を起動（推奨）
 docker-compose up -d
 
 # Prisma の準備
-npx prisma generate
-npx prisma migrate dev --name init
+npm run prisma:generate
+npm run prisma:migrate
 
 # サーバ起動（開発）
 npm run dev
 # http://localhost:3000 で起動
+```
+
+Backend と DB の接続確認:
+
+```bash
+cd backend
+npx prisma validate
+npx prisma migrate status
+curl http://localhost:3000/api/reports
 ```
 
 ### Owner Web アプリの起動


### PR DESCRIPTION
## 概要
- Backend 起動エントリポイントで dotenv/config を preload し、ホスト実行時に backend/.env を読むようにしました。
- backend/.env.example の DATABASE_URL をホスト実行向けの localhost に変更し、Docker Compose の app コンテナ内では postgres を使うことをコメントで明記しました。
- backend README と開発者ワークフローに、Prisma 検証と /api/reports 確認手順を追記しました。

Closes #83

## 検証
- ✅ cd backend && TMPDIR=/tmp npm test -- index-env.spec.ts
- ✅ cd backend && TMPDIR=/tmp npm test
- ✅ cd backend && npm run build
- ✅ cd backend && npx prisma validate
- ✅ cd backend && docker compose up -d postgres
- ✅ cd backend && npm run prisma:migrate
- ✅ cd backend && npx prisma migrate status
- ✅ cd backend && npm start 起動後、curl -i --max-time 10 http://localhost:3000/api/reports が HTTP/1.1 200 OK と [] を返すことを確認

## 補足
- backend/.gitignore は main 時点で .env / dist / node_modules を除外済みだったため、追加変更は不要でした。
- npm install 時に Node 22 と fast-jwt の engine 警告、および既存依存の npm audit 警告が出ましたが、今回の差分では dependency は変更していません。