### PR TITLE
Owner Webの本解除後クーポン表示を修正

### DIFF
--- a/apps/owner-web/__tests__/MarkerPage.test.tsx
+++ b/apps/owner-web/__tests__/MarkerPage.test.tsx
@@ -24,6 +24,9 @@ describe('MarkerPage', () => {
   });
 
   it('can perform temporary unlock and final unlock flow', async () => {
+    let markerStatus = 'temporary';
+    let declarationStatus = 'temporary';
+
     // mock fetch implementation
     (global as any).fetch = jest.fn(async (url: string, opts?: any) => {
       if (
@@ -36,7 +39,7 @@ describe('MarkerPage', () => {
             marker: { code: 'ABC123' },
             report: {
               id: 'r-ABC123',
-              status: 'temporary',
+              status: markerStatus,
               imageUrl: '',
               ocr_text: '',
             },
@@ -44,7 +47,11 @@ describe('MarkerPage', () => {
               declaredAt: '2026-01-19T12:00:00.000Z',
               eligibleFinalAt: '2000-01-01T00:00:00.000Z',
               expiresAt: '2026-01-20T12:00:00.000Z',
-              status: 'temporary',
+              finalizedAt:
+                declarationStatus === 'finalized'
+                  ? '2026-01-19T13:00:00.000Z'
+                  : undefined,
+              status: declarationStatus,
             },
           }),
         };
@@ -69,6 +76,9 @@ describe('MarkerPage', () => {
         url.endsWith('/api/owner/markers/ABC123/unlock-final') &&
         opts?.method === 'POST'
       ) {
+        markerStatus = 'resolved';
+        declarationStatus = 'finalized';
+
         return {
           ok: true,
           json: async () => ({
@@ -112,5 +122,59 @@ describe('MarkerPage', () => {
     fireEvent.click(finalBtn);
 
     await waitFor(() => screen.getByText(/本解除が完了しました/));
+    expect(await screen.findByText(/獲得したクーポン/)).toBeInTheDocument();
+    expect(screen.queryByText(/本解除でクーポンをゲット！/)).toBeNull();
+  });
+
+  it('loads coupons and hides final unlock guidance for resolved markers', async () => {
+    (global as any).fetch = jest.fn(async (url: string, opts?: any) => {
+      if (
+        url.endsWith('/api/owner/markers/ABC123') &&
+        (!opts || opts.method === 'GET')
+      ) {
+        return {
+          ok: true,
+          json: async () => ({
+            marker: { code: 'ABC123' },
+            report: {
+              id: 'r-ABC123',
+              status: 'resolved',
+              imageUrl: '',
+              ocr_text: '',
+            },
+            declaration: {
+              declaredAt: '2026-01-19T12:00:00.000Z',
+              eligibleFinalAt: '2000-01-01T00:00:00.000Z',
+              expiresAt: '2026-01-20T12:00:00.000Z',
+              finalizedAt: '2026-01-19T13:00:00.000Z',
+              status: 'finalized',
+            },
+          }),
+        };
+      }
+
+      if (url.endsWith('/api/owner/markers/ABC123/coupons')) {
+        return {
+          ok: true,
+          json: async () => ({
+            coupons: [
+              {
+                name: '商店街応援クーポン',
+                discount: '100円',
+                discountType: 'fixed',
+              },
+            ],
+          }),
+        };
+      }
+
+      return { ok: false, status: 404, json: async () => ({}) };
+    });
+
+    render(<MarkerPage />);
+
+    expect(await screen.findByText(/獲得したクーポン/)).toBeInTheDocument();
+    expect(screen.getByText('商店街応援クーポン')).toBeInTheDocument();
+    expect(screen.queryByText(/本解除でクーポンをゲット！/)).toBeNull();
   });
 });

--- a/apps/owner-web/pages/markers/[code].tsx
+++ b/apps/owner-web/pages/markers/[code].tsx
@@ -11,6 +11,13 @@ import { getCoupons, getMarker, unlockFinal, unlockTemp } from '../../lib/api';
 import { getUnlockTiming } from '../../lib/owner/time';
 import type { Coupon, MarkerEntry } from '../../lib/owner/types';
 
+function isFinalUnlocked(entry: MarkerEntry) {
+  return (
+    entry.report.status === 'resolved' ||
+    entry.declaration?.status === 'finalized'
+  );
+}
+
 export default function MarkerPage() {
   const router = useRouter();
   const { code } = router.query as { code?: string };
@@ -31,7 +38,17 @@ export default function MarkerPage() {
     setLoading(true);
     setError(null);
     getMarker(code)
-      .then((result) => setData(result))
+      .then(async (result) => {
+        setData(result);
+
+        if (!isFinalUnlocked(result)) {
+          setCoupons([]);
+          return;
+        }
+
+        const couponData = await getCoupons(code);
+        setCoupons(couponData.coupons || []);
+      })
       .catch(() => setError('取得に失敗しました'))
       .finally(() => setLoading(false));
   }, [code]);
@@ -117,6 +134,7 @@ export default function MarkerPage() {
   });
 
   const declaration = data?.declaration;
+  const finalUnlocked = data ? isFinalUnlocked(data) : false;
   const timing = declaration
     ? getUnlockTiming(
         nowTime,
@@ -143,7 +161,7 @@ export default function MarkerPage() {
               disabled={tempUnlockDisabled}
             />
 
-            {declaration && timing && (
+            {declaration && timing && !finalUnlocked && (
               <DeclarationPanel
                 declaration={declaration}
                 eligible={timing.eligible}

--- a/apps/owner-web/tests/e2e/marker.spec.ts
+++ b/apps/owner-web/tests/e2e/marker.spec.ts
@@ -27,4 +27,6 @@ test('owner flow: temp unlock then final unlock', async ({ page, request }) => {
   // status should be resolved on page
   await page.reload();
   await expect(page.locator('text=resolved')).toBeVisible();
+  await expect(page.locator('text=獲得したクーポン')).toBeVisible();
+  await expect(page.locator('text=本解除でクーポンをゲット！')).toHaveCount(0);
 });


### PR DESCRIPTION
## 概要
- Owner Web のマーカー詳細で、初期ロード時に本解除済み状態ならクーポンを取得して表示するようにしました。
- `resolved` / `finalized` 後は本解除待ちの案内パネルを表示しないようにしました。
- UI経由の本解除後と、API本解除後のreload導線をテストで確認しました。

Closes #82

## 原因
API直叩き後のreloadでは画面側の `handleFinal()` が実行されず、初期ロード時にクーポン取得が行われていませんでした。また、本解除済み状態でも `DeclarationPanel` が表示対象に残っていました。

## 検証
- `cd apps/owner-web && npm test -- MarkerPage.test.tsx --runInBand` ✅
- `cd apps/owner-web && npm test` ✅
- `cd apps/owner-web && npm run type-check` ✅
- `cd apps/owner-web && npm run lint` ✅（既存の `ReportSummary.tsx` の `<img>` 警告のみ）
- `cd apps/owner-web && npm run e2e` ✅

## ドキュメント
API・データモデル・長期的な運用判断は変更していないため、`ARCHITECTURE.md` / ADR の更新は不要と判断しました。