### PR TITLE
管理画面の冗長な説明文を削除

### DIFF
--- a/apps/admin-dashboard/__tests__/DashboardPages.test.tsx
+++ b/apps/admin-dashboard/__tests__/DashboardPages.test.tsx
@@ -32,6 +32,14 @@ describe('Admin Dashboard pages', () => {
     expect(screen.getByText('通報日時')).toBeInTheDocument();
     expect(screen.getByText('位置')).toBeInTheDocument();
     expect(screen.getByText('識別情報')).toBeInTheDocument();
+    expect(
+      screen.queryByText(
+        '通報状況の確認、未解除案件の回収依頼、回収結果の記録を行う管理画面の雛形です。',
+      ),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByText('全通報を状態、日時、位置で確認する起点画面です。'),
+    ).not.toBeInTheDocument();
   });
 
   it('shows API report fields on the report list page', () => {
@@ -183,6 +191,11 @@ describe('Admin Dashboard pages', () => {
     render(<UnresolvedPage />);
 
     expect(screen.getByText('reported / temporary')).toBeInTheDocument();
+    expect(
+      screen.queryByText(
+        'reported または temporary の案件を回収依頼候補として確認します。',
+      ),
+    ).not.toBeInTheDocument();
     expect(screen.getByText('防犯登録 1234 / 黒のシティサイクル')).toBeInTheDocument();
     expect(screen.getByText('シール 8842 / 銀のクロスバイク')).toBeInTheDocument();
     expect(
@@ -289,6 +302,9 @@ describe('Admin Dashboard pages', () => {
     expect(screen.getByText('回収依頼')).toBeInTheDocument();
     expect(screen.getByText('依頼メモ')).toBeInTheDocument();
     expect(screen.getByText('確認: collection_requested に更新')).toBeInTheDocument();
+    expect(
+      screen.queryByText('対象案件に依頼メモを付け、回収依頼状態へ更新する雛形です。'),
+    ).not.toBeInTheDocument();
     expect(screen.getByRole('button', { name: '回収依頼登録' })).toBeInTheDocument();
   });
 
@@ -305,6 +321,9 @@ describe('Admin Dashboard pages', () => {
     expect(screen.getByLabelText('回収完了')).toBeInTheDocument();
     expect(screen.getByLabelText('現地で現物なし')).toBeInTheDocument();
     expect(screen.getByText('結果メモ')).toBeInTheDocument();
+    expect(
+      screen.queryByText('回収完了または現地で現物なしの結果を記録する雛形です。'),
+    ).not.toBeInTheDocument();
   });
 
   it('shows loading state until dynamic route params are ready', () => {

--- a/apps/admin-dashboard/components/AppLayout.tsx
+++ b/apps/admin-dashboard/components/AppLayout.tsx
@@ -5,7 +5,6 @@ import type { PropsWithChildren, ReactNode } from 'react';
 
 interface AppLayoutProps extends PropsWithChildren {
   title: string;
-  description: string;
   actions?: ReactNode;
 }
 
@@ -16,7 +15,6 @@ const navItems = [
 
 export function AppLayout({
   title,
-  description,
   actions,
   children,
 }: AppLayoutProps) {
@@ -32,9 +30,6 @@ export function AppLayout({
           <div className="brand-block">
             <p className="eyebrow">NO-Houchi Bicycle Net</p>
             <h1>管理者ダッシュボード</h1>
-            <p className="brand-description">
-              通報状況の確認、未解除案件の回収依頼、回収結果の記録を行う管理画面の雛形です。
-            </p>
           </div>
           <nav className="side-nav" aria-label="グローバルナビゲーション">
             {navItems.map((item) => {
@@ -56,7 +51,6 @@ export function AppLayout({
             <div>
               <p className="eyebrow">運用画面</p>
               <h2>{title}</h2>
-              <p className="page-description">{description}</p>
             </div>
             {actions ? <div className="header-actions">{actions}</div> : null}
           </header>

--- a/apps/admin-dashboard/components/FormScaffold.tsx
+++ b/apps/admin-dashboard/components/FormScaffold.tsx
@@ -3,7 +3,6 @@ import type { PropsWithChildren, ReactNode } from 'react';
 
 interface FormScaffoldProps extends PropsWithChildren {
   title: string;
-  description: string;
   confirmation: string;
   successMessage?: string | null;
   fields: ReactNode;
@@ -13,7 +12,6 @@ interface FormScaffoldProps extends PropsWithChildren {
 
 export function FormScaffold({
   title,
-  description,
   confirmation,
   successMessage,
   fields,
@@ -25,7 +23,6 @@ export function FormScaffold({
     <section className="panel">
       <div className="panel-header">
         <h3>{title}</h3>
-        <p>{description}</p>
       </div>
       {children}
       <div className="form-section">{fields}</div>

--- a/apps/admin-dashboard/pages/collection-request/[id].tsx
+++ b/apps/admin-dashboard/pages/collection-request/[id].tsx
@@ -14,10 +14,7 @@ export default function CollectionRequestPage() {
 
   if (!isReady) {
     return (
-      <AppLayout
-        title="回収依頼"
-        description="対象案件に依頼メモを付け、回収依頼状態へ更新する雛形です。"
-      >
+      <AppLayout title="回収依頼">
         <section className="panel">
           <p>読み込み中…</p>
         </section>
@@ -27,10 +24,7 @@ export default function CollectionRequestPage() {
 
   if (!report) {
     return (
-      <AppLayout
-        title="回収依頼"
-        description="対象の通報情報が見つかりませんでした。"
-      >
+      <AppLayout title="回収依頼">
         <section className="panel">
           <p>対象の通報が見つかりません。</p>
         </section>
@@ -39,21 +33,17 @@ export default function CollectionRequestPage() {
   }
 
   return (
-    <AppLayout
-      title="回収依頼"
-      description="対象案件に依頼メモを付け、回収依頼状態へ更新する雛形です。"
-    >
+    <AppLayout title="回収依頼">
       <form
         onSubmit={(event) => {
           event.preventDefault();
           setSuccessMessage(
-            `回収依頼を登録しました（モック）。入力メモ: ${memo || 'なし'}`,
+            `回収依頼を登録しました。入力メモ: ${memo || 'なし'}`,
           );
         }}
       >
         <FormScaffold
           title="対象概要"
-          description="対象通報の取り違えを避けるため、概要を確認してから登録します。"
           confirmation="確認: collection_requested に更新"
           successMessage={successMessage}
           submitLabel="回収依頼登録"

--- a/apps/admin-dashboard/pages/collection-result/[id].tsx
+++ b/apps/admin-dashboard/pages/collection-result/[id].tsx
@@ -17,10 +17,7 @@ export default function CollectionResultPage() {
 
   if (!isReady) {
     return (
-      <AppLayout
-        title="回収結果記録"
-        description="回収完了または現地で現物なしの結果を記録する雛形です。"
-      >
+      <AppLayout title="回収結果記録">
         <section className="panel">
           <p>読み込み中…</p>
         </section>
@@ -30,10 +27,7 @@ export default function CollectionResultPage() {
 
   if (!report) {
     return (
-      <AppLayout
-        title="回収結果記録"
-        description="対象の通報情報が見つかりませんでした。"
-      >
+      <AppLayout title="回収結果記録">
         <section className="panel">
           <p>対象の通報が見つかりません。</p>
         </section>
@@ -42,21 +36,17 @@ export default function CollectionResultPage() {
   }
 
   return (
-    <AppLayout
-      title="回収結果記録"
-      description="回収完了または現地で現物なしの結果を記録する雛形です。"
-    >
+    <AppLayout title="回収結果記録">
       <form
         onSubmit={(event) => {
           event.preventDefault();
           setSuccessMessage(
-            `結果を記録しました（モック）。選択結果: ${result} / メモ: ${memo || 'なし'}`,
+            `結果を記録しました。選択結果: ${result} / メモ: ${memo || 'なし'}`,
           );
         }}
       >
         <FormScaffold
           title="対象概要"
-          description="回収依頼状態と現地結果の対応を確認してから記録します。"
           confirmation="記録後は collected または not_found_on_collection の完了状態として扱います。"
           successMessage={successMessage}
           submitLabel="結果を記録"

--- a/apps/admin-dashboard/pages/index.tsx
+++ b/apps/admin-dashboard/pages/index.tsx
@@ -25,7 +25,6 @@ export default function HomePage({
   return (
     <AppLayout
       title="通報一覧"
-      description="全通報を状態、日時、位置で確認する起点画面です。"
       actions={
         <div className="header-links">
           <Link href="/unresolved">未解除案件へ</Link>
@@ -35,7 +34,6 @@ export default function HomePage({
       <section className="panel">
         <div className="panel-header">
           <h3>フィルター</h3>
-          <p>状態で通報一覧を絞り込みます。</p>
         </div>
         <nav className="filter-nav" aria-label="状態フィルター">
           <Link

--- a/apps/admin-dashboard/pages/reports/[id].tsx
+++ b/apps/admin-dashboard/pages/reports/[id].tsx
@@ -23,10 +23,7 @@ export default function ReportDetailPage({
 
   if (!isReady) {
     return (
-      <AppLayout
-        title="通報詳細"
-        description="写真、位置、識別情報、現在ステータス、履歴を確認します。"
-      >
+      <AppLayout title="通報詳細">
         <section className="panel">
           <p>読み込み中…</p>
         </section>
@@ -36,10 +33,7 @@ export default function ReportDetailPage({
 
   if (errorMessage || !report) {
     return (
-      <AppLayout
-        title="通報詳細"
-        description="対象の通報情報が見つかりませんでした。"
-      >
+      <AppLayout title="通報詳細">
         <section className="panel">
           <p>{errorMessage ?? '対象の通報が見つかりません。'}</p>
         </section>
@@ -50,7 +44,6 @@ export default function ReportDetailPage({
   return (
     <AppLayout
       title="通報詳細"
-      description="写真、位置、識別情報、現在ステータス、履歴を確認します。"
       actions={
         <div className="header-links">
           {['reported', 'temporary'].includes(report.status) ? (

--- a/apps/admin-dashboard/pages/unresolved.tsx
+++ b/apps/admin-dashboard/pages/unresolved.tsx
@@ -4,10 +4,7 @@ import { unresolvedReports } from '../lib/mockReports';
 
 export default function UnresolvedPage() {
   return (
-    <AppLayout
-      title="未解除案件"
-      description="reported または temporary の案件を回収依頼候補として確認します。"
-    >
+    <AppLayout title="未解除案件">
       <section className="panel">
         <div className="panel-header">
           <h3>絞り込み</h3>

--- a/apps/admin-dashboard/styles/globals.css
+++ b/apps/admin-dashboard/styles/globals.css
@@ -51,14 +51,8 @@ button {
   margin: 0;
 }
 
-.brand-description,
-.page-description,
 .panel-header p {
   color: #52606d;
-}
-
-.sidebar .brand-description {
-  color: #d9e2ec;
 }
 
 .eyebrow {


### PR DESCRIPTION
## 概要
- Admin Dashboard のサイドバーとページヘッダーから冗長な説明文を削除
- 回収依頼・回収結果フォームの説明文と成功メッセージのモック表記を整理
- 説明文が表示されないことをテストで確認

## 検証
- TMPDIR=/tmp npm test -- --runInBand
- npm run type-check
- npm run lint
- npm run build

Closes #89