### PR TITLE
管理者ダッシュボードのモック依存削除とDBシード追加

### DIFF
--- a/apps/admin-dashboard/__tests__/DashboardPages.test.tsx
+++ b/apps/admin-dashboard/__tests__/DashboardPages.test.tsx
@@ -180,14 +180,90 @@ describe('Admin Dashboard pages', () => {
       isReady: true,
     });
 
-    render(<UnresolvedPage />);
+    render(
+      <UnresolvedPage
+        reports={[
+          {
+            id: 'r-1',
+            imageUrl: 'https://example.com/r-1.jpg',
+            reportedAt: '2026-04-20 09:15',
+            location: '大阪市北区中之島 1-2-3',
+            identifierText: '防犯登録 1234 / 黒のシティサイクル',
+            status: 'reported',
+            elapsedLabel: '3時間',
+            currentStatusLabel: 'reported',
+            history: [],
+          },
+          {
+            id: 'r-2',
+            imageUrl: 'https://example.com/r-2.jpg',
+            reportedAt: '2026-04-19 18:40',
+            location: '大阪市北区梅田 2-4-9',
+            identifierText: 'シール 8842 / 銀のクロスバイク',
+            status: 'temporary',
+            elapsedLabel: '17時間',
+            currentStatusLabel: 'temporary',
+            history: [],
+          },
+        ]}
+      />,
+    );
 
     expect(screen.getByText('reported / temporary')).toBeInTheDocument();
     expect(screen.getByText('防犯登録 1234 / 黒のシティサイクル')).toBeInTheDocument();
     expect(screen.getByText('シール 8842 / 銀のクロスバイク')).toBeInTheDocument();
-    expect(
-      screen.queryByText('防犯登録 9981 / 青のママチャリ'),
-    ).not.toBeInTheDocument();
+  });
+
+  it('fetches unresolved reports from the server side', async () => {
+    const originalFetch = global.fetch;
+    const fetchMock = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => [
+        {
+          id: 'r-api-1',
+          imageUrl: 'https://example.com/report-api-1.jpg',
+          latitude: 34.7055,
+          longitude: 135.4983,
+          identifierText: 'API-0001 / 黒のシティサイクル',
+          status: 'reported',
+          createdAt: '2026-04-20T00:15:00.000Z',
+        },
+        {
+          id: 'r-api-2',
+          imageUrl: 'https://example.com/report-api-2.jpg',
+          latitude: 34.706,
+          longitude: 135.4984,
+          identifierText: 'API-0002 / 銀のクロスバイク',
+          status: 'temporary',
+          createdAt: '2026-04-20T00:20:00.000Z',
+        },
+        {
+          id: 'r-api-3',
+          imageUrl: 'https://example.com/report-api-3.jpg',
+          latitude: 34.707,
+          longitude: 135.4985,
+          identifierText: 'API-0003 / 白のミニベロ',
+          status: 'resolved',
+          createdAt: '2026-04-20T00:25:00.000Z',
+        },
+      ],
+    } as Response);
+    global.fetch = fetchMock;
+
+    const { getServerSideProps } = await import('../pages/unresolved');
+    const result = await getServerSideProps({} as never);
+
+    expect(fetchMock).toHaveBeenCalledWith('http://localhost:3000/api/reports');
+    expect(result).toMatchObject({
+      props: {
+        reports: [
+          expect.objectContaining({ id: 'r-api-1', status: 'reported' }),
+          expect.objectContaining({ id: 'r-api-2', status: 'temporary' }),
+        ],
+      },
+    });
+
+    global.fetch = originalFetch;
   });
 
   it('shows overview and history on the report detail page', () => {
@@ -197,7 +273,32 @@ describe('Admin Dashboard pages', () => {
       isReady: true,
     });
 
-    render(<ReportDetailPage />);
+    render(
+      <ReportDetailPage
+        report={{
+          id: 'R-002',
+          imageUrl: '/mock/report-002.png',
+          reportedAt: '2026-04-19 18:40',
+          location: '大阪市北区梅田 2-4-9',
+          identifierText: 'シール 8842 / 銀のクロスバイク',
+          status: 'temporary',
+          elapsedLabel: '17時間',
+          currentStatusLabel: 'temporary',
+          history: [
+            {
+              id: 'H-002',
+              timestamp: '2026-04-19 18:40',
+              label: '通報を受付',
+            },
+            {
+              id: 'H-003',
+              timestamp: '2026-04-19 19:10',
+              label: '持ち主が仮解除',
+            },
+          ],
+        }}
+      />,
+    );
 
     expect(
       screen.getByRole('heading', { level: 2, name: '通報詳細' }),
@@ -284,7 +385,21 @@ describe('Admin Dashboard pages', () => {
       isReady: true,
     });
 
-    render(<CollectionRequestPage />);
+    render(
+      <CollectionRequestPage
+        report={{
+          id: 'R-001',
+          imageUrl: '/mock/report-001.png',
+          reportedAt: '2026-04-20 09:15',
+          location: '大阪市北区中之島 1-2-3',
+          identifierText: '防犯登録 1234 / 黒のシティサイクル',
+          status: 'reported',
+          elapsedLabel: '3時間',
+          currentStatusLabel: 'reported',
+          history: [],
+        }}
+      />,
+    );
 
     expect(screen.getByText('回収依頼')).toBeInTheDocument();
     expect(screen.getByText('依頼メモ')).toBeInTheDocument();
@@ -299,7 +414,21 @@ describe('Admin Dashboard pages', () => {
       isReady: true,
     });
 
-    render(<CollectionResultPage />);
+    render(
+      <CollectionResultPage
+        report={{
+          id: 'R-003',
+          imageUrl: '/mock/report-003.png',
+          reportedAt: '2026-04-18 07:20',
+          location: '大阪市北区天満 3-8-1',
+          identifierText: '防犯登録 9981 / 青のママチャリ',
+          status: 'collection_requested',
+          elapsedLabel: '2日',
+          currentStatusLabel: 'collection_requested',
+          history: [],
+        }}
+      />,
+    );
 
     expect(screen.getByText('回収結果記録')).toBeInTheDocument();
     expect(screen.getByLabelText('回収完了')).toBeInTheDocument();

--- a/apps/admin-dashboard/components/StatusBadge.tsx
+++ b/apps/admin-dashboard/components/StatusBadge.tsx
@@ -1,5 +1,5 @@
 import type { ReportStatus } from '../lib/types';
-import { statusLabelMap } from '../lib/mockReports';
+import { statusLabelMap } from '../lib/reportLabels';
 
 interface StatusBadgeProps {
   status: ReportStatus;

--- a/apps/admin-dashboard/lib/mockReports.ts
+++ b/apps/admin-dashboard/lib/mockReports.ts
@@ -1,13 +1,4 @@
-import type { ReportDetail, ReportStatus } from './types';
-
-export const statusLabelMap: Record<ReportStatus, string> = {
-  reported: 'reported',
-  temporary: 'temporary',
-  resolved: 'resolved',
-  collection_requested: 'collection_requested',
-  collected: 'collected',
-  not_found_on_collection: 'not_found_on_collection',
-};
+import type { ReportDetail } from './types';
 
 export const mockReports: ReportDetail[] = [
   {

--- a/apps/admin-dashboard/lib/reportLabels.ts
+++ b/apps/admin-dashboard/lib/reportLabels.ts
@@ -1,0 +1,10 @@
+import type { ReportStatus } from './types';
+
+export const statusLabelMap: Record<ReportStatus, string> = {
+  reported: 'reported',
+  temporary: 'temporary',
+  resolved: 'resolved',
+  collection_requested: 'collection_requested',
+  collected: 'collected',
+  not_found_on_collection: 'not_found_on_collection',
+};

--- a/apps/admin-dashboard/pages/collection-request/[id].tsx
+++ b/apps/admin-dashboard/pages/collection-request/[id].tsx
@@ -1,14 +1,23 @@
+import type { GetServerSideProps } from 'next';
 import { useState } from 'react';
 import { useRouter } from 'next/router';
 import { AppLayout } from '../../components/AppLayout';
 import { DetailCard } from '../../components/DetailCard';
 import { FormScaffold } from '../../components/FormScaffold';
-import { getReportById } from '../../lib/mockReports';
+import { fetchAdminReport } from '../../lib/adminReports';
+import type { ReportDetail } from '../../lib/types';
 
-export default function CollectionRequestPage() {
+type CollectionRequestPageProps = {
+  report?: ReportDetail;
+  errorMessage?: string;
+};
+
+export default function CollectionRequestPage({
+  report,
+  errorMessage,
+}: CollectionRequestPageProps = {}) {
   const router = useRouter();
   const isReady = router.isReady ?? true;
-  const report = isReady ? getReportById(router.query.id) : undefined;
   const [memo, setMemo] = useState('');
   const [successMessage, setSuccessMessage] = useState<string | null>(null);
 
@@ -25,14 +34,14 @@ export default function CollectionRequestPage() {
     );
   }
 
-  if (!report) {
+  if (errorMessage || !report) {
     return (
       <AppLayout
         title="回収依頼"
         description="対象の通報情報が見つかりませんでした。"
       >
         <section className="panel">
-          <p>対象の通報が見つかりません。</p>
+          <p>{errorMessage ?? '対象の通報が見つかりません。'}</p>
         </section>
       </AppLayout>
     );
@@ -76,3 +85,34 @@ export default function CollectionRequestPage() {
     </AppLayout>
   );
 }
+
+export const getServerSideProps: GetServerSideProps<CollectionRequestPageProps> = async ({
+  params,
+}) => {
+  const id = typeof params?.id === 'string' ? params.id : undefined;
+
+  if (!id) {
+    return {
+      props: {
+        errorMessage: '対象の通報が見つかりません。',
+      },
+    };
+  }
+
+  try {
+    const report = await fetchAdminReport(id);
+
+    return {
+      props: {
+        report,
+      },
+    };
+  } catch (error) {
+    return {
+      props: {
+        errorMessage:
+          '回収依頼対象を取得できませんでした。Backend API の起動状態を確認してください。',
+      },
+    };
+  }
+};

--- a/apps/admin-dashboard/pages/collection-result/[id].tsx
+++ b/apps/admin-dashboard/pages/collection-result/[id].tsx
@@ -1,14 +1,23 @@
+import type { GetServerSideProps } from 'next';
 import { useState } from 'react';
 import { useRouter } from 'next/router';
 import { AppLayout } from '../../components/AppLayout';
 import { DetailCard } from '../../components/DetailCard';
 import { FormScaffold } from '../../components/FormScaffold';
-import { getReportById } from '../../lib/mockReports';
+import { fetchAdminReport } from '../../lib/adminReports';
+import type { ReportDetail } from '../../lib/types';
 
-export default function CollectionResultPage() {
+type CollectionResultPageProps = {
+  report?: ReportDetail;
+  errorMessage?: string;
+};
+
+export default function CollectionResultPage({
+  report,
+  errorMessage,
+}: CollectionResultPageProps = {}) {
   const router = useRouter();
   const isReady = router.isReady ?? true;
-  const report = isReady ? getReportById(router.query.id) : undefined;
   const [result, setResult] = useState<'collected' | 'not_found_on_collection'>(
     'collected',
   );
@@ -28,14 +37,14 @@ export default function CollectionResultPage() {
     );
   }
 
-  if (!report) {
+  if (errorMessage || !report) {
     return (
       <AppLayout
         title="回収結果記録"
         description="対象の通報情報が見つかりませんでした。"
       >
         <section className="panel">
-          <p>対象の通報が見つかりません。</p>
+          <p>{errorMessage ?? '対象の通報が見つかりません。'}</p>
         </section>
       </AppLayout>
     );
@@ -102,3 +111,34 @@ export default function CollectionResultPage() {
     </AppLayout>
   );
 }
+
+export const getServerSideProps: GetServerSideProps<CollectionResultPageProps> = async ({
+  params,
+}) => {
+  const id = typeof params?.id === 'string' ? params.id : undefined;
+
+  if (!id) {
+    return {
+      props: {
+        errorMessage: '対象の通報が見つかりません。',
+      },
+    };
+  }
+
+  try {
+    const report = await fetchAdminReport(id);
+
+    return {
+      props: {
+        report,
+      },
+    };
+  } catch (error) {
+    return {
+      props: {
+        errorMessage:
+          '回収結果対象を取得できませんでした。Backend API の起動状態を確認してください。',
+      },
+    };
+  }
+};

--- a/apps/admin-dashboard/pages/reports/[id].tsx
+++ b/apps/admin-dashboard/pages/reports/[id].tsx
@@ -5,7 +5,6 @@ import { AppLayout } from '../../components/AppLayout';
 import { DetailCard } from '../../components/DetailCard';
 import { HistoryList } from '../../components/HistoryList';
 import { fetchAdminReport } from '../../lib/adminReports';
-import { getReportById } from '../../lib/mockReports';
 import type { ReportDetail } from '../../lib/types';
 
 type ReportDetailPageProps = {
@@ -19,7 +18,7 @@ export default function ReportDetailPage({
 }: ReportDetailPageProps = {}) {
   const router = useRouter();
   const isReady = router.isReady ?? true;
-  const report = reportFromProps ?? (isReady ? getReportById(router.query.id) : undefined);
+  const report = reportFromProps;
 
   if (!isReady) {
     return (

--- a/apps/admin-dashboard/pages/unresolved.tsx
+++ b/apps/admin-dashboard/pages/unresolved.tsx
@@ -1,8 +1,18 @@
+import type { GetServerSideProps } from 'next';
 import { AppLayout } from '../components/AppLayout';
 import { ReportsTable } from '../components/ReportsTable';
-import { unresolvedReports } from '../lib/mockReports';
+import { fetchAdminReports } from '../lib/adminReports';
+import type { ReportDetail } from '../lib/types';
 
-export default function UnresolvedPage() {
+type UnresolvedPageProps = {
+  reports: ReportDetail[];
+  errorMessage?: string;
+};
+
+export default function UnresolvedPage({
+  reports,
+  errorMessage,
+}: UnresolvedPageProps) {
   return (
     <AppLayout
       title="未解除案件"
@@ -14,11 +24,39 @@ export default function UnresolvedPage() {
           <p>reported / temporary</p>
         </div>
       </section>
-      <ReportsTable
-        reports={unresolvedReports}
-        showElapsed
-        actionMode="collectionRequest"
-      />
+      {errorMessage ? (
+        <section className="panel error-panel" role="alert">
+          {errorMessage}
+        </section>
+      ) : (
+        <ReportsTable
+          reports={reports}
+          showElapsed
+          actionMode="collectionRequest"
+        />
+      )}
     </AppLayout>
   );
 }
+
+export const getServerSideProps: GetServerSideProps<UnresolvedPageProps> = async () => {
+  try {
+    const reports = await fetchAdminReports('all');
+
+    return {
+      props: {
+        reports: reports.filter((report) =>
+          ['reported', 'temporary'].includes(report.status),
+        ),
+      },
+    };
+  } catch (error) {
+    return {
+      props: {
+        reports: [],
+        errorMessage:
+          '未解除案件を取得できませんでした。Backend API の起動状態を確認してください。',
+      },
+    };
+  }
+};

--- a/backend/package.json
+++ b/backend/package.json
@@ -8,7 +8,11 @@
     "start": "node dist/index.js",
     "prisma:generate": "prisma generate",
     "prisma:migrate": "prisma migrate dev --name init",
+    "prisma:seed": "prisma db seed",
     "test": "vitest"
+  },
+  "prisma": {
+    "seed": "ts-node --transpile-only prisma/seed.ts"
   },
   "dependencies": {
     "@azure/ai-form-recognizer": "^5.1.0",

--- a/backend/prisma/seed.ts
+++ b/backend/prisma/seed.ts
@@ -1,0 +1,401 @@
+import { PrismaClient } from '@prisma/client';
+import bcrypt from 'bcryptjs';
+
+const prisma = new PrismaClient();
+
+const now = new Date('2026-05-11T09:00:00.000Z');
+
+function daysAgo(days: number) {
+  return new Date(now.getTime() - days * 24 * 60 * 60 * 1000);
+}
+
+function daysFromNow(days: number) {
+  return new Date(now.getTime() + days * 24 * 60 * 60 * 1000);
+}
+
+async function main() {
+  const password = await bcrypt.hash('password123', 10);
+
+  const admin = await prisma.user.upsert({
+    where: { email: 'admin@example.test' },
+    update: {
+      name: '北区 管理担当',
+      password,
+      role: 'admin',
+    },
+    create: {
+      id: 'seed-user-admin',
+      name: '北区 管理担当',
+      email: 'admin@example.test',
+      password,
+      role: 'admin',
+    },
+  });
+
+  const owner = await prisma.user.upsert({
+    where: { email: 'owner@example.test' },
+    update: {
+      name: '開発用 持ち主',
+      password,
+      role: 'user',
+    },
+    create: {
+      id: 'seed-user-owner',
+      name: '開発用 持ち主',
+      email: 'owner@example.test',
+      password,
+      role: 'user',
+    },
+  });
+
+  const activeBike = await prisma.bike.upsert({
+    where: { serialNumber: 'SEED-BIKE-001' },
+    update: {
+      status: 'rented',
+      location: '大阪市北区中之島',
+    },
+    create: {
+      id: 'seed-bike-001',
+      serialNumber: 'SEED-BIKE-001',
+      status: 'rented',
+      location: '大阪市北区中之島',
+    },
+  });
+
+  await prisma.bike.upsert({
+    where: { serialNumber: 'SEED-BIKE-002' },
+    update: {
+      status: 'available',
+      location: '大阪市北区梅田',
+    },
+    create: {
+      id: 'seed-bike-002',
+      serialNumber: 'SEED-BIKE-002',
+      status: 'available',
+      location: '大阪市北区梅田',
+    },
+  });
+
+  await prisma.rental.upsert({
+    where: { id: 'seed-rental-active' },
+    update: {
+      userId: owner.id,
+      bikeId: activeBike.id,
+      startAt: daysAgo(1),
+      endAt: null,
+      status: 'active',
+    },
+    create: {
+      id: 'seed-rental-active',
+      userId: owner.id,
+      bikeId: activeBike.id,
+      startAt: daysAgo(1),
+      status: 'active',
+    },
+  });
+
+  const markers = await Promise.all([
+    upsertMarker('seed-marker-reported', 'SEED-REP-001', '大阪市北区中之島 1-2-3'),
+    upsertMarker('seed-marker-temporary', 'SEED-TMP-001', '大阪市北区梅田 2-4-9'),
+    upsertMarker('seed-marker-collection', 'SEED-COL-001', '大阪市北区天満 3-8-1'),
+    upsertMarker('seed-marker-collected', 'SEED-DONE-001', '大阪市北区堂島 1-5-2'),
+    upsertMarker('seed-marker-not-found', 'SEED-NF-001', '大阪市北区芝田 1-1-4'),
+    upsertMarker('seed-marker-resolved', 'SEED-RES-001', '大阪市北区扇町 2-1-7'),
+  ]);
+
+  const [
+    reportedMarker,
+    temporaryMarker,
+    collectionMarker,
+    collectedMarker,
+    notFoundMarker,
+    resolvedMarker,
+  ] = markers;
+
+  const reports = await Promise.all([
+    upsertReport({
+      id: 'seed-report-reported',
+      markerId: reportedMarker.id,
+      imageUrl: 'https://example.com/seed/report-reported.jpg',
+      latitude: 34.693724,
+      longitude: 135.502254,
+      identifierText: '防犯登録 SEED-1001 / 黒のシティサイクル',
+      status: 'reported',
+      notes: '開発用: 未解除一覧と回収依頼導線の確認用',
+      createdAt: daysAgo(1),
+    }),
+    upsertReport({
+      id: 'seed-report-temporary',
+      markerId: temporaryMarker.id,
+      imageUrl: 'https://example.com/seed/report-temporary.jpg',
+      latitude: 34.702485,
+      longitude: 135.495951,
+      identifierText: 'シール SEED-2001 / 銀のクロスバイク',
+      status: 'temporary',
+      notes: '開発用: 持ち主が仮解除済みの案件',
+      createdAt: daysAgo(2),
+    }),
+    upsertReport({
+      id: 'seed-report-collection-requested',
+      markerId: collectionMarker.id,
+      imageUrl: 'https://example.com/seed/report-collection-requested.jpg',
+      latitude: 34.697587,
+      longitude: 135.511032,
+      identifierText: '防犯登録 SEED-3001 / 青のママチャリ',
+      status: 'collection_requested',
+      notes: '開発用: 回収依頼中の案件',
+      createdAt: daysAgo(3),
+    }),
+    upsertReport({
+      id: 'seed-report-collected',
+      markerId: collectedMarker.id,
+      imageUrl: 'https://example.com/seed/report-collected.jpg',
+      latitude: 34.696112,
+      longitude: 135.498924,
+      identifierText: '防犯登録 SEED-4001 / 白のミニベロ',
+      status: 'collected',
+      notes: '開発用: 回収完了案件',
+      createdAt: daysAgo(4),
+    }),
+    upsertReport({
+      id: 'seed-report-not-found',
+      markerId: notFoundMarker.id,
+      imageUrl: 'https://example.com/seed/report-not-found.jpg',
+      latitude: 34.705534,
+      longitude: 135.49811,
+      identifierText: 'ステッカー SEED-5001 / 赤のロードバイク',
+      status: 'not_found_on_collection',
+      notes: '開発用: 現地で現物なしの案件',
+      createdAt: daysAgo(5),
+    }),
+    upsertReport({
+      id: 'seed-report-resolved',
+      markerId: resolvedMarker.id,
+      imageUrl: 'https://example.com/seed/report-resolved.jpg',
+      latitude: 34.704177,
+      longitude: 135.510109,
+      identifierText: '防犯登録 SEED-6001 / 緑のシティサイクル',
+      status: 'resolved',
+      notes: '開発用: 持ち主が本解除済みの案件',
+      createdAt: daysAgo(6),
+    }),
+  ]);
+
+  await Promise.all([
+    upsertDeclaration({
+      id: 'seed-declaration-temporary',
+      markerId: temporaryMarker.id,
+      declaredAt: daysAgo(1),
+      eligibleFinalAt: new Date(daysAgo(1).getTime() + 15 * 60 * 1000),
+      expiresAt: daysFromNow(1),
+      finalizedAt: null,
+      status: 'temporary',
+      notes: '開発用: 仮解除中',
+    }),
+    upsertDeclaration({
+      id: 'seed-declaration-resolved',
+      markerId: resolvedMarker.id,
+      declaredAt: daysAgo(6),
+      eligibleFinalAt: new Date(daysAgo(6).getTime() + 15 * 60 * 1000),
+      expiresAt: daysAgo(5),
+      finalizedAt: daysAgo(5),
+      status: 'resolved',
+      notes: '開発用: 本解除済み',
+    }),
+  ]);
+
+  await Promise.all([
+    upsertCollectionRequest({
+      id: 'seed-collection-request-pending',
+      reportId: reports[2].id,
+      requestedBy: admin.name,
+      requestedAt: daysAgo(2),
+      result: 'pending',
+      resultRecordedBy: null,
+      resultRecordedAt: null,
+      notes: '歩道上に継続駐輪。回収を依頼済み。',
+    }),
+    upsertCollectionRequest({
+      id: 'seed-collection-request-collected',
+      reportId: reports[3].id,
+      requestedBy: admin.name,
+      requestedAt: daysAgo(3),
+      result: 'collected',
+      resultRecordedBy: '北区 回収業者',
+      resultRecordedAt: daysAgo(2),
+      notes: '回収業者が現地で回収完了。',
+    }),
+    upsertCollectionRequest({
+      id: 'seed-collection-request-not-found',
+      reportId: reports[4].id,
+      requestedBy: admin.name,
+      requestedAt: daysAgo(4),
+      result: 'not_found_on_collection',
+      resultRecordedBy: '北区 回収業者',
+      resultRecordedAt: daysAgo(3),
+      notes: '現地確認時に現物なし。',
+    }),
+  ]);
+
+  const coupons = await Promise.all([
+    upsertCoupon({
+      id: 'seed-coupon-shopping-500',
+      name: '商店街お買い物券500円',
+      description: '商店街の加盟店で使える500円分のお買い物券',
+      shopName: '北区商店街',
+      discount: 500,
+      discountType: 'amount',
+      validDays: 30,
+      isActive: true,
+    }),
+    upsertCoupon({
+      id: 'seed-coupon-cafe-20',
+      name: 'カフェ20%割引券',
+      description: 'カフェ利用時に20%割引',
+      shopName: '商店街カフェ',
+      discount: 20,
+      discountType: 'percentage',
+      validDays: 14,
+      isActive: true,
+    }),
+  ]);
+
+  await Promise.all([
+    upsertCouponIssuance({
+      id: 'seed-coupon-issuance-active',
+      couponId: coupons[0].id,
+      userId: owner.id,
+      markerId: resolvedMarker.id,
+      ownerEmail: owner.email,
+      issuedAt: daysAgo(5),
+      expiresAt: daysFromNow(25),
+      usedAt: null,
+      status: 'active',
+    }),
+    upsertCouponIssuance({
+      id: 'seed-coupon-issuance-used',
+      couponId: coupons[1].id,
+      userId: null,
+      markerId: resolvedMarker.id,
+      ownerEmail: 'guest-owner@example.test',
+      issuedAt: daysAgo(10),
+      expiresAt: daysFromNow(4),
+      usedAt: daysAgo(8),
+      status: 'used',
+    }),
+  ]);
+}
+
+async function upsertMarker(id: string, code: string, location: string) {
+  return prisma.marker.upsert({
+    where: { code },
+    update: { location },
+    create: { id, code, location },
+  });
+}
+
+async function upsertReport(input: {
+  id: string;
+  markerId: string;
+  imageUrl: string;
+  latitude: number;
+  longitude: number;
+  identifierText: string;
+  status: string;
+  notes: string;
+  createdAt: Date;
+}) {
+  return prisma.bicycleReport.upsert({
+    where: { id: input.id },
+    update: {
+      markerId: input.markerId,
+      imageUrl: input.imageUrl,
+      latitude: input.latitude,
+      longitude: input.longitude,
+      identifierText: input.identifierText,
+      status: input.status,
+      notes: input.notes,
+      createdAt: input.createdAt,
+    },
+    create: input,
+  });
+}
+
+async function upsertDeclaration(input: {
+  id: string;
+  markerId: string;
+  declaredAt: Date;
+  eligibleFinalAt: Date;
+  expiresAt: Date;
+  finalizedAt: Date | null;
+  status: string;
+  notes: string;
+}) {
+  return prisma.declaration.upsert({
+    where: { id: input.id },
+    update: input,
+    create: input,
+  });
+}
+
+async function upsertCollectionRequest(input: {
+  id: string;
+  reportId: string;
+  requestedBy: string | null;
+  requestedAt: Date;
+  result: string;
+  resultRecordedBy: string | null;
+  resultRecordedAt: Date | null;
+  notes: string;
+}) {
+  return prisma.collectionRequest.upsert({
+    where: { id: input.id },
+    update: input,
+    create: input,
+  });
+}
+
+async function upsertCoupon(input: {
+  id: string;
+  name: string;
+  description: string;
+  shopName: string;
+  discount: number;
+  discountType: string;
+  validDays: number;
+  isActive: boolean;
+}) {
+  return prisma.coupon.upsert({
+    where: { id: input.id },
+    update: input,
+    create: input,
+  });
+}
+
+async function upsertCouponIssuance(input: {
+  id: string;
+  couponId: string;
+  userId: string | null;
+  markerId: string;
+  ownerEmail: string;
+  issuedAt: Date;
+  expiresAt: Date;
+  usedAt: Date | null;
+  status: string;
+}) {
+  return prisma.couponIssuance.upsert({
+    where: { id: input.id },
+    update: input,
+    create: input,
+  });
+}
+
+main()
+  .then(async () => {
+    await prisma.$disconnect();
+  })
+  .catch(async (error) => {
+    console.error(error);
+    await prisma.$disconnect();
+    process.exit(1);
+  });


### PR DESCRIPTION
## 概要
- 管理者ダッシュボードの実画面からモック依存を外し、一覧・未解除・詳細・回収依頼・回収結果を API ベースに統一しました。
- ローカル開発用に Prisma seed を追加し、通報系を含む一通りの初期データを投入できるようにしました。
- npm run test は API 起動なしで動く状態を維持しています。

## 変更点
- /unresolved を API 取得に変更
- /reports/[id]、/collection-request/[id]、/collection-result/[id] を API 由来データで表示
- StatusBadge のラベル定義をモック本体から分離
- backend/prisma/seed.ts を追加し、prisma db seed の実行経路を追加
- テストは fetch モックで完結するよう更新

## 検証
- cd apps/admin-dashboard && TMPDIR=/tmp npm test -- --runInBand
- cd apps/admin-dashboard && npm run type-check
- cd apps/admin-dashboard && npm run lint
- cd backend && npm run prisma:generate
- cd backend && TMPDIR=/tmp npm test
- cd backend && npm run build
- cd backend && npx tsc --noEmit --target ES2022 --module CommonJS --moduleResolution Node --esModuleInterop --skipLibCheck --types node prisma/seed.ts
- cd backend && npx prisma validate

## 補足
- cd backend && npm run prisma:seed は DB 未起動のため localhost:5432 に接続できず失敗しました。seed コマンドの起動までは確認済みです。