### PR TITLE
マーカー画面の読み込み停止を修正

### DIFF
--- a/apps/owner-web/.env.example
+++ b/apps/owner-web/.env.example
@@ -1,0 +1,6 @@
+# Backend API
+# Leave empty to use the owner-web development API mocks.
+OWNER_API_BASE_URL=
+
+# Shared backend API setting, also supported for parity with admin-dashboard.
+# NEXT_PUBLIC_API_BASE_URL=http://localhost:3000

--- a/apps/owner-web/README.md
+++ b/apps/owner-web/README.md
@@ -10,7 +10,19 @@ Development scaffold for the owner-facing web app.
 
 Dev server runs on http://localhost:3001 by default.
 
-This scaffold includes simple API mocks under `pages/api/owner/markers/[code]` for development and testing.
+This scaffold includes simple API mocks under `pages/api/owner/markers/[...path]` for development and testing.
+
+## Backend API
+
+By default, owner-web uses the local development API mocks.
+
+To proxy owner API requests to a backend server, copy `.env.example` to `.env.local` and set:
+
+```bash
+OWNER_API_BASE_URL=http://localhost:3000
+```
+
+`NEXT_PUBLIC_API_BASE_URL` is also supported for parity with admin-dashboard.
 
 ## Structure
 
@@ -18,4 +30,4 @@ This scaffold includes simple API mocks under `pages/api/owner/markers/[code]` f
 - `components/owner/`: owner flow presentation components.
 - `hooks/`: reusable browser-side hooks such as QR scanning and time updates.
 - `lib/owner/`: owner flow types, API client helpers, time utilities, and shared development API store.
-- `pages/api/owner/markers/[code]`: development API mocks for marker lookup, temporary unlock, final unlock, coupons, and E2E helpers.
+- `pages/api/owner/markers/[...path]`: development API mocks for marker lookup, temporary unlock, final unlock, coupons, and E2E helpers.

--- a/apps/owner-web/__tests__/MarkerPage.test.tsx
+++ b/apps/owner-web/__tests__/MarkerPage.test.tsx
@@ -24,8 +24,8 @@ describe('MarkerPage', () => {
   });
 
   it('can perform temporary unlock and final unlock flow', async () => {
-    let markerStatus = 'temporary';
-    let declarationStatus = 'temporary';
+    let markerStatus = 'reported';
+    let declarationStatus: 'none' | 'temporary' | 'finalized' = 'none';
 
     // mock fetch implementation
     (global as any).fetch = jest.fn(async (url: string, opts?: any) => {
@@ -43,16 +43,19 @@ describe('MarkerPage', () => {
               imageUrl: '',
               ocr_text: '',
             },
-            declaration: {
-              declaredAt: '2026-01-19T12:00:00.000Z',
-              eligibleFinalAt: '2000-01-01T00:00:00.000Z',
-              expiresAt: '2026-01-20T12:00:00.000Z',
-              finalizedAt:
-                declarationStatus === 'finalized'
-                  ? '2026-01-19T13:00:00.000Z'
-                  : undefined,
-              status: declarationStatus,
-            },
+            declaration:
+              declarationStatus === 'none'
+                ? null
+                : {
+                    declaredAt: '2026-01-19T12:00:00.000Z',
+                    eligibleFinalAt: '2000-01-01T00:00:00.000Z',
+                    expiresAt: '2099-01-20T12:00:00.000Z',
+                    finalizedAt:
+                      declarationStatus === 'finalized'
+                        ? '2026-01-19T13:00:00.000Z'
+                        : undefined,
+                    status: declarationStatus,
+                  },
           }),
         };
       }
@@ -61,12 +64,15 @@ describe('MarkerPage', () => {
         url.endsWith('/api/owner/markers/ABC123/unlock-temp') &&
         opts?.method === 'POST'
       ) {
+        markerStatus = 'temporary';
+        declarationStatus = 'temporary';
+
         return {
           ok: true,
           json: async () => ({
             declaredAt: '2026-01-19T12:00:00.000Z',
             eligibleFinalAt: '2000-01-01T00:00:00.000Z',
-            expiresAt: '2026-01-20T12:00:00.000Z',
+            expiresAt: '2099-01-20T12:00:00.000Z',
             status: 'temporary',
           }),
         };
@@ -176,5 +182,40 @@ describe('MarkerPage', () => {
     expect(await screen.findByText(/獲得したクーポン/)).toBeInTheDocument();
     expect(screen.getByText('商店街応援クーポン')).toBeInTheDocument();
     expect(screen.queryByText(/本解除でクーポンをゲット！/)).toBeNull();
+  });
+
+  it('shows marker data even when coupons cannot be loaded', async () => {
+    (global as any).fetch = jest.fn(async (url: string, opts?: any) => {
+      if (
+        url.endsWith('/api/owner/markers/ABC123') &&
+        (!opts || opts.method === 'GET')
+      ) {
+        return {
+          ok: true,
+          json: async () => ({
+            marker: { code: 'ABC123' },
+            report: {
+              id: 'r-ABC123',
+              status: 'reported',
+              imageUrl: '',
+              ocr_text: '',
+            },
+            declaration: null,
+          }),
+        };
+      }
+
+      if (url.endsWith('/api/owner/markers/ABC123/coupons')) {
+        return { ok: false, status: 500, statusText: 'Internal Server Error' };
+      }
+
+      return { ok: false, status: 404, json: async () => ({}) };
+    });
+
+    render(<MarkerPage />);
+
+    expect(await screen.findByText('仮解除を申請する')).toBeInTheDocument();
+    expect(screen.queryByText('読み込み中…')).toBeNull();
+    expect(screen.queryByText('取得に失敗しました')).toBeNull();
   });
 });

--- a/apps/owner-web/__tests__/api/ownerMarkers.test.ts
+++ b/apps/owner-web/__tests__/api/ownerMarkers.test.ts
@@ -1,0 +1,69 @@
+/** @jest-environment node */
+import handler from '../../pages/api/owner/markers/[...path]';
+import { clearOwnerStore } from '../../lib/owner/store';
+
+function createResponse() {
+  const res = {
+    statusCode: 200,
+    body: undefined as unknown,
+    status(code: number) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload: unknown) {
+      this.body = payload;
+      return this;
+    },
+  };
+
+  return res;
+}
+
+async function request(method: string, path: string[]) {
+  const req = { method, query: { path } };
+  const res = createResponse();
+
+  await handler(req as any, res as any);
+
+  return res;
+}
+
+describe('owner marker API mocks', () => {
+  beforeEach(() => {
+    clearOwnerStore();
+  });
+
+  it('returns marker data from the owner-web dev server', async () => {
+    const res = await request('GET', ['ABC123']);
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toMatchObject({
+      marker: { code: 'ABC123' },
+      report: { status: 'reported' },
+      declaration: null,
+    });
+  });
+
+  it('supports temporary unlock, final unlock, and coupon listing', async () => {
+    const temp = await request('POST', ['ABC123', 'unlock-temp']);
+    expect(temp.statusCode).toBe(200);
+    expect(temp.body).toMatchObject({ status: 'temporary' });
+
+    const eligible = await request('POST', [
+      'ABC123',
+      '__test__',
+      'set-eligible-past',
+    ]);
+    expect(eligible.statusCode).toBe(200);
+
+    const final = await request('POST', ['ABC123', 'unlock-final']);
+    expect(final.statusCode).toBe(200);
+    expect(final.body).toMatchObject({ status: 'resolved' });
+
+    const coupons = await request('GET', ['ABC123', 'coupons']);
+    expect(coupons.statusCode).toBe(200);
+    expect(coupons.body).toMatchObject({
+      coupons: [{ name: '商店街応援クーポン' }],
+    });
+  });
+});

--- a/apps/owner-web/__tests__/nextConfig.test.ts
+++ b/apps/owner-web/__tests__/nextConfig.test.ts
@@ -1,0 +1,50 @@
+/** @jest-environment node */
+
+function loadConfig() {
+  jest.resetModules();
+  return require('../next.config');
+}
+
+describe('next config', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+    delete process.env.OWNER_API_BASE_URL;
+    delete process.env.NEXT_PUBLIC_API_BASE_URL;
+  });
+
+  afterAll(() => {
+    process.env = originalEnv;
+  });
+
+  it('keeps owner API requests local when backend URL is not configured', async () => {
+    const config = loadConfig();
+
+    await expect(config.rewrites()).resolves.toEqual([]);
+  });
+
+  it('proxies owner API requests to configured backend URL', async () => {
+    process.env.OWNER_API_BASE_URL = 'http://localhost:4000/';
+    const config = loadConfig();
+
+    await expect(config.rewrites()).resolves.toEqual([
+      {
+        source: '/api/owner/:path*',
+        destination: 'http://localhost:4000/owner/:path*',
+      },
+    ]);
+  });
+
+  it('falls back to NEXT_PUBLIC_API_BASE_URL like admin-dashboard', async () => {
+    process.env.NEXT_PUBLIC_API_BASE_URL = 'http://localhost:3000';
+    const config = loadConfig();
+
+    await expect(config.rewrites()).resolves.toEqual([
+      {
+        source: '/api/owner/:path*',
+        destination: 'http://localhost:3000/owner/:path*',
+      },
+    ]);
+  });
+});

--- a/apps/owner-web/next.config.js
+++ b/apps/owner-web/next.config.js
@@ -1,11 +1,25 @@
 /** @type {import('next').NextConfig} */
+function getOwnerApiBaseUrl() {
+  return (
+    process.env.OWNER_API_BASE_URL ||
+    process.env.NEXT_PUBLIC_API_BASE_URL ||
+    ''
+  ).replace(/\/$/, '');
+}
+
 const nextConfig = {
   reactStrictMode: true,
   async rewrites() {
+    const apiBaseUrl = getOwnerApiBaseUrl();
+
+    if (!apiBaseUrl) {
+      return [];
+    }
+
     return [
       {
         source: '/api/owner/:path*',
-        destination: 'http://localhost:4000/owner/:path*',
+        destination: `${apiBaseUrl}/owner/:path*`,
       },
     ];
   },

--- a/apps/owner-web/pages/api/owner/markers/[...path].ts
+++ b/apps/owner-web/pages/api/owner/markers/[...path].ts
@@ -1,0 +1,59 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import {
+  declareTemporaryUnlock,
+  finalizeUnlock,
+  getCouponsForMarker,
+  getMarkerEntry,
+  setEligibleFinalAtInPast,
+} from '../../../../lib/owner/store';
+
+function getPath(queryPath: string | string[] | undefined) {
+  return Array.isArray(queryPath) ? queryPath : queryPath ? [queryPath] : [];
+}
+
+export default function handler(req: NextApiRequest, res: NextApiResponse) {
+  const [code, action, subAction] = getPath(req.query.path);
+
+  if (!code) {
+    return res.status(400).json({ error: 'marker code is required' });
+  }
+
+  if (req.method === 'GET' && !action) {
+    return res.status(200).json(getMarkerEntry(code));
+  }
+
+  if (req.method === 'POST' && action === 'unlock-temp') {
+    return res.status(200).json(declareTemporaryUnlock(code));
+  }
+
+  if (req.method === 'POST' && action === 'unlock-final') {
+    try {
+      return res.status(200).json(finalizeUnlock(code));
+    } catch (err) {
+      return res.status(400).json({
+        error:
+          err instanceof Error ? err.message : 'failed to finalize unlock',
+      });
+    }
+  }
+
+  if (req.method === 'GET' && action === 'coupons') {
+    return res.status(200).json({ coupons: getCouponsForMarker(code) });
+  }
+
+  if (
+    req.method === 'POST' &&
+    action === '__test__' &&
+    subAction === 'set-eligible-past'
+  ) {
+    const declaration = setEligibleFinalAtInPast(code);
+
+    if (!declaration) {
+      return res.status(404).json({ error: 'declaration not found' });
+    }
+
+    return res.status(200).json(declaration);
+  }
+
+  return res.status(404).json({ error: 'not found' });
+}

--- a/apps/owner-web/pages/markers/[code].tsx
+++ b/apps/owner-web/pages/markers/[code].tsx
@@ -41,10 +41,15 @@ export default function MarkerPage() {
 
     setLoading(true);
     setError(null);
-    Promise.all([getMarker(code), getCoupons(code)])
-      .then(([markerResult, couponResult]) => {
+    getMarker(code)
+      .then(async (markerResult) => {
         setData(markerResult);
-        setCoupons(couponResult.coupons || []);
+        try {
+          const couponResult = await getCoupons(code);
+          setCoupons(couponResult.coupons || []);
+        } catch {
+          setCoupons([]);
+        }
       })
       .catch(() => setError('取得に失敗しました'))
       .finally(() => setLoading(false));


### PR DESCRIPTION
## 概要
- owner-web の開発用 API mock を追加し、localhost:3001 単体でマーカー画面を表示できるようにしました
- /api/owner/* のバックエンド proxy は .env の OWNER_API_BASE_URL または NEXT_PUBLIC_API_BASE_URL が設定された時だけ有効にしました
- owner-web に .env.example を追加し、admin-dashboard と同じようにバックエンド URL を設定できるようにしました
- 初期表示でクーポン取得に失敗してもマーカー情報を表示し続けるようにしました

## 確認
- TMPDIR=/tmp npm test -- --cacheDirectory=/tmp/jest-owner-web
- npm run type-check
- npm run lint（既存の next/no-img-element warning のみ）
- npm run build
- curl http://localhost:3011/markers/ABC123 -> 200
- curl http://localhost:3011/api/owner/markers/ABC123 -> marker JSON