### PR TITLE
Issue #32 バリデーションとエラー処理を整備

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -22,6 +22,7 @@ NO-Houchi Bicycle Net is a monorepo for a prototype civic-tech platform targetin
 ## Boundaries
 
 - `backend/prisma/schema.prisma` is the source of truth for implemented database model names and relations.
+- `backend` の `/api/reports*` は管理 API として扱い、JWT 認証済みかつ `admin` ロールの呼び出しを前提にする。`/owner/*` は公開ルートのまま維持する。
 - API documentation should be updated with API behavior changes; do not leave docs and route behavior intentionally divergent.
 - CI is not used by project policy. Verification is local and should be documented in PR notes or task plans.
 - Prototype scope should remain distinct from future-scope features.

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -6,6 +6,7 @@ import bikeRoutes from './routes/bikes';
 import ownerRoutes from './routes/owner';
 import reportRoutes from './routes/reports';
 import { sendError, UnauthorizedError } from './lib/errors';
+import { requireAdmin } from './lib/auth';
 import { AuthService } from './services/authService';
 import type { OCRService } from './services/ocrService';
 
@@ -39,9 +40,7 @@ export function buildServer({ prisma, ocrService, now }: BuildServerOptions = {}
   // Protected route example
   server.get('/users/me', async (request, reply) => {
     try {
-      await request.jwtVerify();
-      const tokenPayload = request.user as { sub?: string | number } | undefined;
-      const userId = tokenPayload?.sub ? String(tokenPayload.sub) : '';
+      const { userId } = await requireAdmin(request);
       const authService = new AuthService(server.prisma as any);
       const user = await authService.getUserProfile(userId);
       return reply.send(user);

--- a/backend/src/lib/auth.ts
+++ b/backend/src/lib/auth.ts
@@ -1,0 +1,30 @@
+import type { FastifyRequest } from 'fastify';
+import { ForbiddenError, UnauthorizedError } from './errors';
+
+type JwtUser = {
+  sub?: string | number;
+  role?: string;
+};
+
+export async function requireAdmin(request: FastifyRequest) {
+  try {
+    await request.jwtVerify();
+  } catch {
+    throw new UnauthorizedError('Unauthorized');
+  }
+
+  const user = request.user as JwtUser | undefined;
+
+  if (!user?.sub) {
+    throw new UnauthorizedError('Unauthorized');
+  }
+
+  if (user.role !== 'admin') {
+    throw new ForbiddenError('Forbidden');
+  }
+
+  return {
+    userId: String(user.sub),
+    role: user.role,
+  };
+}

--- a/backend/src/lib/errors.ts
+++ b/backend/src/lib/errors.ts
@@ -35,6 +35,12 @@ export class ConflictError extends AppError {
   }
 }
 
+export class ForbiddenError extends AppError {
+  constructor(message = 'Forbidden', details?: Record<string, unknown>) {
+    super(message, 403, details);
+  }
+}
+
 export function sendError(reply: FastifyReply, logger: FastifyBaseLogger, error: unknown) {
   if (error instanceof AppError) {
     return reply.status(error.statusCode).send({

--- a/backend/src/lib/validation.ts
+++ b/backend/src/lib/validation.ts
@@ -1,0 +1,86 @@
+import { BadRequestError } from './errors';
+
+const emailPattern = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+export const reportStatuses = [
+  'reported',
+  'temporary',
+  'resolved',
+  'collection_requested',
+  'collected',
+  'not_found_on_collection',
+] as const;
+
+export type ReportStatus = (typeof reportStatuses)[number];
+
+export function normalizeOptionalString(value: string | null | undefined) {
+  if (typeof value !== 'string') {
+    return null;
+  }
+
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+export function requireNonBlankString(value: string | null | undefined, message: string) {
+  const normalized = normalizeOptionalString(value);
+
+  if (!normalized) {
+    throw new BadRequestError(message);
+  }
+
+  return normalized;
+}
+
+export function validateEmail(value: string | null | undefined, fieldName = 'email') {
+  const normalized = requireNonBlankString(value, `${fieldName} required`);
+
+  if (!emailPattern.test(normalized)) {
+    throw new BadRequestError(`${fieldName} must be a valid email address`);
+  }
+
+  return normalized;
+}
+
+export function validateOptionalEmail(value: string | null | undefined, fieldName = 'email') {
+  const normalized = normalizeOptionalString(value);
+
+  if (!normalized) {
+    return null;
+  }
+
+  if (!emailPattern.test(normalized)) {
+    throw new BadRequestError(`${fieldName} must be a valid email address`);
+  }
+
+  return normalized;
+}
+
+export function validateCoordinates(latitude: unknown, longitude: unknown) {
+  if (
+    typeof latitude !== 'number' ||
+    typeof longitude !== 'number' ||
+    !Number.isFinite(latitude) ||
+    !Number.isFinite(longitude)
+  ) {
+    throw new BadRequestError('latitude and longitude must be numbers');
+  }
+
+  if (latitude < -90 || latitude > 90 || longitude < -180 || longitude > 180) {
+    throw new BadRequestError('latitude and longitude must be valid coordinates');
+  }
+
+  return { latitude, longitude };
+}
+
+export function validateReportStatus(status: string | undefined) {
+  if (!status) {
+    return undefined;
+  }
+
+  if (reportStatuses.includes(status as ReportStatus)) {
+    return status as ReportStatus;
+  }
+
+  throw new BadRequestError('status must be a valid report status');
+}

--- a/backend/src/routes/bikes.ts
+++ b/backend/src/routes/bikes.ts
@@ -1,5 +1,6 @@
 import type { FastifyPluginAsync } from 'fastify';
 import { BadRequestError, sendError } from '../lib/errors';
+import { normalizeOptionalString } from '../lib/validation';
 import { BikeService } from '../services/bikeService';
 import { getOCRService, type OCRService } from '../services/ocrService';
 
@@ -74,13 +75,15 @@ export default function createBikeRoutes(options: { ocrService?: OCRService } = 
 
     fastify.post<{ Body: OCRRequestBody }>('/ocr/recognize', async (request, reply) => {
       try {
-        if (!request.body?.filePath) {
+        const filePath = normalizeOptionalString(request.body?.filePath);
+
+        if (!filePath) {
           throw new BadRequestError('filePath required', {
             message: 'FTPから取得した画像ファイルのパスを指定してください',
           });
         }
 
-        const result = await resolveOCRService().recognizeRegistrationNumber(request.body.filePath);
+        const result = await resolveOCRService().recognizeRegistrationNumber(filePath);
 
         if (!result.success) {
           return reply.status(400).send({

--- a/backend/src/routes/owner.ts
+++ b/backend/src/routes/owner.ts
@@ -1,5 +1,6 @@
 import type { FastifyPluginAsync } from 'fastify';
 import { sendError } from '../lib/errors';
+import { requireNonBlankString } from '../lib/validation';
 import { CouponService } from '../services/couponService';
 import { OwnerUnlockService } from '../services/ownerUnlockService';
 
@@ -31,7 +32,9 @@ export default function createOwnerRoutes(options: { now?: () => Date } = {}): F
 
     fastify.get<{ Params: MarkerParams }>('/markers/:code', async (request, reply) => {
       try {
-        const response = await ownerUnlockService.getMarkerEntry(request.params.code);
+        const response = await ownerUnlockService.getMarkerEntry(
+          requireNonBlankString(request.params.code, 'marker code required')
+        );
         return reply.send(response);
       } catch (error) {
         console.error('[GET /markers/:code] Error:', error);
@@ -41,7 +44,9 @@ export default function createOwnerRoutes(options: { now?: () => Date } = {}): F
 
     fastify.get<{ Params: MarkerParams }>('/markers/:code/coupons', async (request, reply) => {
       try {
-        const response = await ownerUnlockService.getCouponsByMarkerCode(request.params.code);
+        const response = await ownerUnlockService.getCouponsByMarkerCode(
+          requireNonBlankString(request.params.code, 'marker code required')
+        );
         return reply.send(response);
       } catch (error) {
         return sendError(reply, fastify.log, error);
@@ -52,7 +57,10 @@ export default function createOwnerRoutes(options: { now?: () => Date } = {}): F
       '/markers/:code/unlock-final',
       async (request, reply) => {
         try {
-          const response = await ownerUnlockService.finalizeUnlock(request.params.code, request.body ?? {});
+          const response = await ownerUnlockService.finalizeUnlock(
+            requireNonBlankString(request.params.code, 'marker code required'),
+            request.body ?? {}
+          );
           return reply.send(response);
         } catch (error) {
           return sendError(reply, fastify.log, error);
@@ -63,10 +71,11 @@ export default function createOwnerRoutes(options: { now?: () => Date } = {}): F
     fastify.post<{ Params: MarkerParams; Body: TemporaryUnlockBody }>(
       '/markers/:code/unlock-temp',
       async (request, reply) => {
-        console.log(`[unlock-temp] Received request for code: ${request.params.code}`);
         try {
+          const code = requireNonBlankString(request.params.code, 'marker code required');
+          console.log(`[unlock-temp] Received request for code: ${code}`);
           const response = await ownerUnlockService.createTemporaryUnlock(
-            request.params.code,
+            code,
             request.body?.notes
           );
           console.log(`[unlock-temp] Success:`, JSON.stringify(response));

--- a/backend/src/routes/reports.ts
+++ b/backend/src/routes/reports.ts
@@ -1,4 +1,5 @@
 import type { FastifyPluginAsync } from 'fastify';
+import { requireAdmin } from '../lib/auth';
 import { sendError } from '../lib/errors';
 import { ReportService } from '../services/reportService';
 
@@ -35,6 +36,7 @@ const reportRoutes: FastifyPluginAsync = async (fastify) => {
 
   fastify.get<{ Querystring: ListReportsQuery }>('/', async (request, reply) => {
     try {
+      await requireAdmin(request);
       const reports = await reportService.listReports(request.query ?? {});
       return reply.send(reports);
     } catch (error) {
@@ -44,6 +46,7 @@ const reportRoutes: FastifyPluginAsync = async (fastify) => {
 
   fastify.get<{ Params: ReportParams }>('/:id', async (request, reply) => {
     try {
+      await requireAdmin(request);
       const report = await reportService.getReport(request.params.id);
       return reply.send(report);
     } catch (error) {
@@ -53,6 +56,7 @@ const reportRoutes: FastifyPluginAsync = async (fastify) => {
 
   fastify.post<{ Body: CreateReportBody }>('/', async (request, reply) => {
     try {
+      await requireAdmin(request);
       const report = await reportService.createReport(request.body ?? {});
       return reply.status(201).send(report);
     } catch (error) {
@@ -64,6 +68,7 @@ const reportRoutes: FastifyPluginAsync = async (fastify) => {
     '/:id/collection-request',
     async (request, reply) => {
       try {
+        await requireAdmin(request);
         const report = await reportService.requestCollection(request.params.id, request.body ?? {});
         return reply.send(report);
       } catch (error) {
@@ -76,6 +81,7 @@ const reportRoutes: FastifyPluginAsync = async (fastify) => {
     '/:id/collection-result',
     async (request, reply) => {
       try {
+        await requireAdmin(request);
         const report = await reportService.recordCollectionResult(request.params.id, request.body ?? {});
         return reply.send(report);
       } catch (error) {

--- a/backend/src/services/authService.ts
+++ b/backend/src/services/authService.ts
@@ -1,5 +1,6 @@
 import bcrypt from 'bcryptjs';
 import { BadRequestError, ConflictError, NotFoundError, UnauthorizedError } from '../lib/errors';
+import { normalizeOptionalString, validateEmail, requireNonBlankString } from '../lib/validation';
 
 type RegisterInput = {
   name?: string | null;
@@ -41,22 +42,28 @@ export class AuthService {
   constructor(private readonly prisma: AuthPrisma) {}
 
   async register(input: RegisterInput): Promise<PublicUser> {
-    if (!input.email || !input.password) {
+    const rawEmail = normalizeOptionalString(input.email);
+    const rawPassword = normalizeOptionalString(input.password);
+
+    if (!rawEmail || !rawPassword) {
       throw new BadRequestError('email and password required');
     }
 
+    const email = validateEmail(rawEmail);
+    const password = requireNonBlankString(rawPassword, 'email and password required');
+
     const existing = await this.prisma.user.findUnique({
-      where: { email: input.email },
+      where: { email },
     });
     if (existing) {
       throw new ConflictError('email already in use');
     }
 
-    const hashedPassword = await bcrypt.hash(input.password, 10);
+    const hashedPassword = await bcrypt.hash(password, 10);
     return this.prisma.user.create({
       data: {
         name: input.name ?? null,
-        email: input.email,
+        email,
         password: hashedPassword,
       },
       select: {
@@ -70,19 +77,25 @@ export class AuthService {
   }
 
   async login(input: LoginInput): Promise<{ id: string; email: string; role: string }> {
-    if (!input.email || !input.password) {
+    const rawEmail = normalizeOptionalString(input.email);
+    const rawPassword = normalizeOptionalString(input.password);
+
+    if (!rawEmail || !rawPassword) {
       throw new BadRequestError('email and password required');
     }
 
+    const email = validateEmail(rawEmail);
+    const password = requireNonBlankString(rawPassword, 'email and password required');
+
     const user = (await this.prisma.user.findUnique({
-      where: { email: input.email },
+      where: { email },
     })) as UserRecord | null;
 
     if (!user) {
       throw new UnauthorizedError('invalid credentials');
     }
 
-    const validPassword = await bcrypt.compare(input.password, user.password);
+    const validPassword = await bcrypt.compare(password, user.password);
     if (!validPassword) {
       throw new UnauthorizedError('invalid credentials');
     }

--- a/backend/src/services/bikeService.ts
+++ b/backend/src/services/bikeService.ts
@@ -1,4 +1,5 @@
 import { BadRequestError, ConflictError, NotFoundError } from '../lib/errors';
+import { normalizeOptionalString, requireNonBlankString } from '../lib/validation';
 
 type BikeRecord = {
   id: string;
@@ -32,12 +33,10 @@ export class BikeService {
   }
 
   async createBike(input: { serialNumber?: string; location?: string | null; status?: string }) {
-    if (!input.serialNumber) {
-      throw new BadRequestError('serialNumber required');
-    }
+    const serialNumber = requireNonBlankString(input.serialNumber, 'serialNumber required');
 
     const existing = await this.prisma.bike.findUnique({
-      where: { serialNumber: input.serialNumber },
+      where: { serialNumber },
     });
     if (existing) {
       throw new ConflictError('serialNumber already exists');
@@ -45,8 +44,8 @@ export class BikeService {
 
     return this.prisma.bike.create({
       data: {
-        serialNumber: input.serialNumber,
-        location: input.location ?? null,
+        serialNumber,
+        location: normalizeOptionalString(input.location) ?? null,
         status: input.status ?? 'available',
       },
     });

--- a/backend/src/services/ownerUnlockService.ts
+++ b/backend/src/services/ownerUnlockService.ts
@@ -1,4 +1,9 @@
-import { BadRequestError, NotFoundError } from '../lib/errors';
+import { BadRequestError, ConflictError, NotFoundError } from '../lib/errors';
+import {
+  normalizeOptionalString,
+  requireNonBlankString,
+  validateOptionalEmail,
+} from '../lib/validation';
 import { CouponService } from './couponService';
 
 type MarkerRecord = {
@@ -82,8 +87,9 @@ export class OwnerUnlockService {
   ) {}
 
   async getMarkerEntry(code: string) {
+    const normalizedCode = requireNonBlankString(code, 'marker code required');
     const marker = await this.prisma.marker.findUnique({
-      where: { code },
+      where: { code: normalizedCode },
     });
 
     if (!marker) {
@@ -118,8 +124,9 @@ export class OwnerUnlockService {
   }
 
   async getCouponsByMarkerCode(code: string) {
+    const normalizedCode = requireNonBlankString(code, 'marker code required');
     const marker = await this.prisma.marker.findUnique({
-      where: { code },
+      where: { code: normalizedCode },
     });
 
     if (!marker) {
@@ -135,7 +142,8 @@ export class OwnerUnlockService {
   }
 
   async createTemporaryUnlock(code: string, notes?: string) {
-    const marker = await this.getOrCreateMarker(code);
+    const normalizedCode = requireNonBlankString(code, 'marker code required');
+    const marker = await this.getOrCreateMarker(normalizedCode);
 
     // 問題5: 解決済みマーカーの再仮解除を禁止
     const resolvedDeclaration = await this.prisma.declaration.findFirst({
@@ -145,7 +153,7 @@ export class OwnerUnlockService {
       },
     });
     if (resolvedDeclaration) {
-      throw new BadRequestError('このマーカーは既に本解除が完了しています');
+      throw new ConflictError('このマーカーは既に本解除が完了しています');
     }
 
     const declaredAt = this.now();
@@ -170,7 +178,7 @@ export class OwnerUnlockService {
         eligibleFinalAt,
         expiresAt,
         status: 'temporary',
-        notes: notes ?? null,
+        notes: normalizeOptionalString(notes) ?? null,
       },
     });
 
@@ -189,19 +197,19 @@ export class OwnerUnlockService {
   }
 
   async finalizeUnlock(code: string, input: { scannedCode?: string; ownerEmail?: string | null }) {
-    if (!input.scannedCode) {
-      throw new BadRequestError('scannedCode required');
-    }
+    const normalizedCode = requireNonBlankString(code, 'marker code required');
+    const scannedCode = requireNonBlankString(input.scannedCode, 'scannedCode required');
+    const ownerEmail = validateOptionalEmail(input.ownerEmail, 'ownerEmail');
 
-    if (input.scannedCode !== code) {
+    if (scannedCode !== normalizedCode) {
       throw new BadRequestError('scannedCode does not match marker code');
     }
 
     const marker = await this.prisma.marker.findUnique({
-      where: { code },
+      where: { code: normalizedCode },
     });
     if (!marker) {
-      throw new BadRequestError('No temporary declaration found');
+      throw new NotFoundError('Marker not found');
     }
 
     const declaration = await this.prisma.declaration.findFirst({
@@ -213,12 +221,12 @@ export class OwnerUnlockService {
     });
 
     if (!declaration) {
-      throw new BadRequestError('No temporary declaration found');
+      throw new ConflictError('No temporary declaration found');
     }
 
     const finalizedAt = this.now();
     if (finalizedAt < declaration.eligibleFinalAt) {
-      throw new BadRequestError('eligibleFinalAt has not arrived', {
+      throw new ConflictError('eligibleFinalAt has not arrived', {
         eligibleFinalAt: declaration.eligibleFinalAt,
         currentTime: finalizedAt,
       });
@@ -231,7 +239,7 @@ export class OwnerUnlockService {
         where: { id: declaration.id },
         data: { status: 'expired' },
       });
-      throw new BadRequestError('仮解除の有効期限（24時間）が切れています。再度仮解除を行ってください');
+      throw new ConflictError('仮解除の有効期限（24時間）が切れています。再度仮解除を行ってください');
     }
 
     await this.prisma.declaration.update({
@@ -250,7 +258,7 @@ export class OwnerUnlockService {
 
     const coupon = await this.couponService.issueCouponForFinalUnlock(
       marker.id,
-      input.ownerEmail ?? null,
+      ownerEmail,
       finalizedAt
     );
 

--- a/backend/src/services/reportService.ts
+++ b/backend/src/services/reportService.ts
@@ -1,4 +1,10 @@
-import { BadRequestError, NotFoundError } from '../lib/errors';
+import { BadRequestError, ConflictError, NotFoundError } from '../lib/errors';
+import {
+  normalizeOptionalString,
+  requireNonBlankString,
+  validateCoordinates,
+  validateReportStatus,
+} from '../lib/validation';
 
 type MarkerRecord = {
   id: string;
@@ -114,8 +120,10 @@ export class ReportService {
   constructor(private readonly prisma: ReportPrisma) {}
 
   async listReports(input: { status?: string }) {
+    const status = validateReportStatus(input.status);
+
     return this.prisma.bicycleReport.findMany({
-      where: input.status ? { status: input.status } : undefined,
+      where: status ? { status } : undefined,
       orderBy: { createdAt: 'desc' },
     });
   }
@@ -140,35 +148,24 @@ export class ReportService {
     identifierText?: string;
     notes?: string | null;
   }) {
-    if (!input.imageUrl) {
-      throw new BadRequestError('imageUrl required');
-    }
+    const imageUrl = requireNonBlankString(input.imageUrl, 'imageUrl required');
+    const markerCode = requireNonBlankString(input.markerCode, 'markerCode required');
+    const identifierText = requireNonBlankString(input.identifierText, 'identifierText required');
+    const { latitude, longitude } = validateCoordinates(input.latitude, input.longitude);
 
-    if (typeof input.latitude !== 'number' || typeof input.longitude !== 'number') {
-      throw new BadRequestError('latitude and longitude must be numbers');
-    }
-
-    if (!input.markerCode) {
-      throw new BadRequestError('markerCode required');
-    }
-
-    if (!input.identifierText) {
-      throw new BadRequestError('identifierText required');
-    }
-
-    const marker = await this.getOrCreateMarker(input.markerCode);
-    const address = await this.resolveAddress(input.latitude, input.longitude);
+    const marker = await this.getOrCreateMarker(markerCode);
+    const address = await this.resolveAddress(latitude, longitude);
 
     return this.prisma.bicycleReport.create({
       data: {
         markerId: marker.id,
-        imageUrl: input.imageUrl,
-        latitude: input.latitude,
-        longitude: input.longitude,
+        imageUrl,
+        latitude,
+        longitude,
         address,
-        identifierText: input.identifierText,
+        identifierText,
         status: 'reported',
-        notes: input.notes ?? null,
+        notes: normalizeOptionalString(input.notes) ?? null,
       },
     });
   }
@@ -183,7 +180,7 @@ export class ReportService {
     }
 
     if (report.status !== 'reported') {
-      throw new BadRequestError('report is not eligible for collection request');
+      throw new ConflictError('report is not eligible for collection request');
     }
 
     const requestedAt = new Date();
@@ -200,16 +197,16 @@ export class ReportService {
       });
 
       if (updateResult.count !== 1) {
-        throw new BadRequestError('report is not eligible for collection request');
+        throw new ConflictError('report is not eligible for collection request');
       }
 
       await tx.collectionRequest.create({
         data: {
           reportId: report.id,
-          requestedBy: input.requestedBy ?? null,
+          requestedBy: normalizeOptionalString(input.requestedBy) ?? null,
           requestedAt,
           result: 'pending',
-          notes: input.notes ?? null,
+          notes: normalizeOptionalString(input.notes) ?? null,
         },
       });
 
@@ -240,7 +237,7 @@ export class ReportService {
     const result = this.parseCollectionResult(input.result);
 
     if (report.status !== 'collection_requested') {
-      throw new BadRequestError('report is not eligible for collection result');
+      throw new ConflictError('report is not eligible for collection result');
     }
 
     const resultRecordedAt = new Date();
@@ -255,7 +252,7 @@ export class ReportService {
       });
 
       if (!pendingRequest) {
-        throw new BadRequestError('pending collection request not found');
+        throw new ConflictError('pending collection request not found');
       }
 
       const updateResult = await tx.bicycleReport.updateMany({
@@ -269,16 +266,16 @@ export class ReportService {
       });
 
       if (updateResult.count !== 1) {
-        throw new BadRequestError('report is not eligible for collection result');
+        throw new ConflictError('report is not eligible for collection result');
       }
 
       await tx.collectionRequest.update({
         where: { id: pendingRequest.id },
         data: {
           result,
-          resultRecordedBy: input.resultRecordedBy ?? null,
+          resultRecordedBy: normalizeOptionalString(input.resultRecordedBy) ?? null,
           resultRecordedAt,
-          notes: input.notes ?? null,
+          notes: normalizeOptionalString(input.notes) ?? null,
         },
       });
 

--- a/backend/test/auth.spec.ts
+++ b/backend/test/auth.spec.ts
@@ -58,6 +58,28 @@ describe('auth', () => {
     expect(JSON.parse(res.payload)).toEqual({ error: 'email already in use' });
   });
 
+  it('rejects invalid email format on register', async () => {
+    const res = await server.inject({
+      method: 'POST',
+      url: '/auth/register',
+      payload: { email: 'invalid-email', password: 'pass' },
+    });
+
+    expect(res.statusCode).toBe(400);
+    expect(JSON.parse(res.payload)).toEqual({ error: 'email must be a valid email address' });
+  });
+
+  it('rejects blank email or password on register', async () => {
+    const res = await server.inject({
+      method: 'POST',
+      url: '/auth/register',
+      payload: { email: '   ', password: '   ' },
+    });
+
+    expect(res.statusCode).toBe(400);
+    expect(JSON.parse(res.payload)).toEqual({ error: 'email and password required' });
+  });
+
   it('rejects invalid credentials on login', async () => {
     const res = await server.inject({
       method: 'POST',
@@ -69,18 +91,40 @@ describe('auth', () => {
     expect(JSON.parse(res.payload)).toEqual({ error: 'invalid credentials' });
   });
 
+  it('rejects invalid email format on login', async () => {
+    const res = await server.inject({
+      method: 'POST',
+      url: '/auth/login',
+      payload: { email: 'invalid-email', password: 'secret123' },
+    });
+
+    expect(res.statusCode).toBe(400);
+    expect(JSON.parse(res.payload)).toEqual({ error: 'email must be a valid email address' });
+  });
+
+  it('rejects blank email or password on login', async () => {
+    const res = await server.inject({
+      method: 'POST',
+      url: '/auth/login',
+      payload: { email: ' ', password: ' ' },
+    });
+
+    expect(res.statusCode).toBe(400);
+    expect(JSON.parse(res.payload)).toEqual({ error: 'email and password required' });
+  });
+
   it('accesses protected route /users/me', async () => {
     const hashed = await bcrypt.hash('p', 10);
     const user = await mockPrisma.prisma.user.create({
       data: { name: 'Me', email: 'me@example.com', password: hashed },
     });
     // sign with server's jwt
-    const token = server.jwt.sign({ sub: user.id, email: user.email });
+    const adminToken = server.jwt.sign({ sub: user.id, email: user.email, role: 'admin' });
 
     const res = await server.inject({
       method: 'GET',
       url: '/users/me',
-      headers: { authorization: `Bearer ${token}` },
+      headers: { authorization: `Bearer ${adminToken}` },
     });
     expect(res.statusCode).toBe(200);
     const body = JSON.parse(res.payload);

--- a/backend/test/bikes.spec.ts
+++ b/backend/test/bikes.spec.ts
@@ -82,6 +82,17 @@ describe('bikes', () => {
     expect(JSON.parse(res.payload)).toEqual({ error: 'serialNumber already exists' });
   });
 
+  it('rejects blank serial number', async () => {
+    const res = await server.inject({
+      method: 'POST',
+      url: '/bikes',
+      payload: { serialNumber: '   ' },
+    });
+
+    expect(res.statusCode).toBe(400);
+    expect(JSON.parse(res.payload)).toEqual({ error: 'serialNumber required' });
+  });
+
   it('returns 404 for missing bike', async () => {
     const getRes = await server.inject({
       method: 'GET',
@@ -118,6 +129,20 @@ describe('bikes', () => {
         confidence: 0.91,
         rawText: '防犯登録 12345678',
       },
+    });
+  });
+
+  it('rejects blank OCR filePath', async () => {
+    const res = await server.inject({
+      method: 'POST',
+      url: '/bikes/ocr/recognize',
+      payload: { filePath: '   ' },
+    });
+
+    expect(res.statusCode).toBe(400);
+    expect(JSON.parse(res.payload)).toEqual({
+      error: 'filePath required',
+      message: 'FTPから取得した画像ファイルのパスを指定してください',
     });
   });
 });

--- a/backend/test/owner.spec.ts
+++ b/backend/test/owner.spec.ts
@@ -185,13 +185,17 @@ describe('owner', () => {
   });
 
   it('rejects final unlock when no temporary declaration exists', async () => {
+    await prismaBundle.prisma.marker.create({
+      data: { code: 'NO-DECLARATION' },
+    });
+
     const response = await server.inject({
       method: 'POST',
       url: '/owner/markers/NO-DECLARATION/unlock-final',
       payload: { scannedCode: 'NO-DECLARATION' },
     });
 
-    expect(response.statusCode).toBe(400);
+    expect(response.statusCode).toBe(409);
     expect(JSON.parse(response.payload)).toEqual({ error: 'No temporary declaration found' });
   });
 
@@ -202,7 +206,7 @@ describe('owner', () => {
       payload: { scannedCode: 'ABC123' },
     });
 
-    expect(response.statusCode).toBe(400);
+    expect(response.statusCode).toBe(409);
     expect(JSON.parse(response.payload)).toMatchObject({
       error: 'eligibleFinalAt has not arrived',
       eligibleFinalAt: '2026-04-20T09:15:00.000Z',
@@ -221,6 +225,32 @@ describe('owner', () => {
     expect(response.statusCode).toBe(400);
     expect(JSON.parse(response.payload)).toEqual({
       error: 'scannedCode does not match marker code',
+    });
+  });
+
+  it('rejects final unlock when scannedCode is blank', async () => {
+    const response = await server.inject({
+      method: 'POST',
+      url: '/owner/markers/ABC123/unlock-final',
+      payload: { scannedCode: '   ' },
+    });
+
+    expect(response.statusCode).toBe(400);
+    expect(JSON.parse(response.payload)).toEqual({
+      error: 'scannedCode required',
+    });
+  });
+
+  it('rejects final unlock when ownerEmail is invalid', async () => {
+    const response = await server.inject({
+      method: 'POST',
+      url: '/owner/markers/ABC123/unlock-final',
+      payload: { scannedCode: 'ABC123', ownerEmail: 'invalid-email' },
+    });
+
+    expect(response.statusCode).toBe(400);
+    expect(JSON.parse(response.payload)).toEqual({
+      error: 'ownerEmail must be a valid email address',
     });
   });
 
@@ -269,6 +299,43 @@ describe('owner', () => {
       status: 'resolved',
       coupon: null,
       message: '本解除が完了しました',
+    });
+  });
+
+  it('returns 404 when final unlock target marker does not exist', async () => {
+    const response = await server.inject({
+      method: 'POST',
+      url: '/owner/markers/UNKNOWN-MARKER/unlock-final',
+      payload: { scannedCode: 'UNKNOWN-MARKER' },
+    });
+
+    expect(response.statusCode).toBe(404);
+    expect(JSON.parse(response.payload)).toEqual({
+      error: 'Marker not found',
+    });
+  });
+
+  it('returns 409 when final unlock is attempted after temporary unlock expiry', async () => {
+    currentTime = new Date('2026-04-20T12:00:00.000Z');
+
+    const tempResponse = await server.inject({
+      method: 'POST',
+      url: '/owner/markers/EXPIRED-001/unlock-temp',
+      payload: {},
+    });
+    expect(tempResponse.statusCode).toBe(200);
+
+    currentTime = new Date('2026-04-21T12:01:00.000Z');
+
+    const response = await server.inject({
+      method: 'POST',
+      url: '/owner/markers/EXPIRED-001/unlock-final',
+      payload: { scannedCode: 'EXPIRED-001' },
+    });
+
+    expect(response.statusCode).toBe(409);
+    expect(JSON.parse(response.payload)).toEqual({
+      error: '仮解除の有効期限（24時間）が切れています。再度仮解除を行ってください',
     });
   });
 

--- a/backend/test/reports.spec.ts
+++ b/backend/test/reports.spec.ts
@@ -1,21 +1,56 @@
 import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
 import { buildServer } from '../src/app';
-import { BadRequestError } from '../src/lib/errors';
+import { ConflictError } from '../src/lib/errors';
 import { ReportService } from '../src/services/reportService';
 import { createMockPrisma } from './helpers/mockPrisma';
 
 describe('reports', () => {
   let server: any;
   let prismaBundle: ReturnType<typeof createMockPrisma>;
+  let adminAuthHeader: Record<string, string>;
+  let userAuthHeader: Record<string, string>;
   const originalGoogleMapsApiKey = process.env.GOOGLE_MAPS_API_KEY;
   const originalFetch = global.fetch;
 
-  beforeAll(() => {
+  beforeAll(async () => {
     process.env.GOOGLE_MAPS_API_KEY = '';
     prismaBundle = createMockPrisma();
     server = buildServer({
       prisma: prismaBundle.prisma as any,
     });
+    await server.ready();
+
+    const adminUser = await prismaBundle.prisma.user.create({
+      data: {
+        name: 'Admin User',
+        email: 'admin@example.test',
+        password: 'hashed-password',
+        role: 'admin',
+      },
+    });
+    const normalUser = await prismaBundle.prisma.user.create({
+      data: {
+        name: 'Normal User',
+        email: 'user@example.test',
+        password: 'hashed-password',
+        role: 'user',
+      },
+    });
+
+    adminAuthHeader = {
+      authorization: `Bearer ${server.jwt.sign({
+        sub: adminUser.id,
+        email: adminUser.email,
+        role: adminUser.role,
+      })}`,
+    };
+    userAuthHeader = {
+      authorization: `Bearer ${server.jwt.sign({
+        sub: normalUser.id,
+        email: normalUser.email,
+        role: normalUser.role,
+      })}`,
+    };
   });
 
   afterAll(async () => {
@@ -28,6 +63,7 @@ describe('reports', () => {
     const response = await server.inject({
       method: 'POST',
       url: '/api/reports',
+      headers: adminAuthHeader,
       payload: {
         imageUrl: 'https://example.com/report-1.jpg',
         latitude: 34.7055,
@@ -74,6 +110,7 @@ describe('reports', () => {
     const response = await isolatedServer.inject({
       method: 'POST',
       url: '/api/reports',
+      headers: adminAuthHeader,
       payload: {
         imageUrl: 'https://example.com/report-address.jpg',
         latitude: 34.7055,
@@ -107,6 +144,7 @@ describe('reports', () => {
     const response = await isolatedServer.inject({
       method: 'POST',
       url: '/api/reports',
+      headers: adminAuthHeader,
       payload: {
         imageUrl: 'https://example.com/report-address-failure.jpg',
         latitude: 34.706,
@@ -162,6 +200,7 @@ describe('reports', () => {
     const response = await server.inject({
       method: 'GET',
       url: '/api/reports',
+      headers: adminAuthHeader,
     });
 
     expect(response.statusCode).toBe(200);
@@ -176,6 +215,7 @@ describe('reports', () => {
     const response = await server.inject({
       method: 'GET',
       url: '/api/reports?status=collection_requested',
+      headers: adminAuthHeader,
     });
 
     expect(response.statusCode).toBe(200);
@@ -190,6 +230,7 @@ describe('reports', () => {
     const response = await server.inject({
       method: 'GET',
       url: '/api/reports/r-2',
+      headers: adminAuthHeader,
     });
 
     expect(response.statusCode).toBe(200);
@@ -206,6 +247,7 @@ describe('reports', () => {
     const response = await server.inject({
       method: 'GET',
       url: '/api/reports/r-999',
+      headers: adminAuthHeader,
     });
 
     expect(response.statusCode).toBe(404);
@@ -216,6 +258,7 @@ describe('reports', () => {
     const response = await server.inject({
       method: 'POST',
       url: '/api/reports/r-2/collection-request',
+      headers: adminAuthHeader,
       payload: {
         notes: '歩道上のため回収依頼',
         requestedBy: '北区役所 管理担当',
@@ -245,6 +288,7 @@ describe('reports', () => {
     const response = await server.inject({
       method: 'POST',
       url: '/api/reports/r-999/collection-request',
+      headers: adminAuthHeader,
       payload: {
         requestedBy: '北区役所 管理担当',
       },
@@ -270,12 +314,13 @@ describe('reports', () => {
       const response = await server.inject({
         method: 'POST',
         url: `/api/reports/${report.id}/collection-request`,
+        headers: adminAuthHeader,
         payload: {
           requestedBy: '北区役所 管理担当',
         },
       });
 
-      expect(response.statusCode).toBe(400);
+      expect(response.statusCode).toBe(409);
       expect(JSON.parse(response.payload)).toEqual({ error: 'report is not eligible for collection request' });
       expect(prismaBundle.state.reports.get(report.id)!.status).toBe(status);
     }
@@ -314,7 +359,7 @@ describe('reports', () => {
       reportService.requestCollection(report.id, {
         requestedBy: '北区役所 管理担当',
       })
-    ).rejects.toBeInstanceOf(BadRequestError);
+    ).rejects.toBeInstanceOf(ConflictError);
 
     expect(isolatedPrismaBundle.state.collectionRequests.size).toBe(0);
     expect(isolatedPrismaBundle.state.reports.get(report.id)!.status).toBe('collection_requested');
@@ -335,6 +380,7 @@ describe('reports', () => {
     await server.inject({
       method: 'POST',
       url: `/api/reports/${report.id}/collection-request`,
+      headers: adminAuthHeader,
       payload: {
         requestedBy: '北区役所 管理担当',
       },
@@ -343,6 +389,7 @@ describe('reports', () => {
     const response = await server.inject({
       method: 'PATCH',
       url: `/api/reports/${report.id}/collection-result`,
+      headers: adminAuthHeader,
       payload: {
         result: 'collected',
         resultRecordedBy: '北区 回収業者',
@@ -384,11 +431,13 @@ describe('reports', () => {
     await server.inject({
       method: 'POST',
       url: `/api/reports/${report.id}/collection-request`,
+      headers: adminAuthHeader,
     });
 
     const response = await server.inject({
       method: 'PATCH',
       url: `/api/reports/${report.id}/collection-result`,
+      headers: adminAuthHeader,
       payload: {
         result: 'not_found_on_collection',
       },
@@ -415,6 +464,7 @@ describe('reports', () => {
     const response = await server.inject({
       method: 'PATCH',
       url: '/api/reports/r-999/collection-result',
+      headers: adminAuthHeader,
       payload: {
         result: 'collected',
       },
@@ -428,6 +478,7 @@ describe('reports', () => {
     const response = await server.inject({
       method: 'PATCH',
       url: '/api/reports/r-2/collection-result',
+      headers: adminAuthHeader,
       payload: {
         result: 'resolved',
       },
@@ -453,12 +504,13 @@ describe('reports', () => {
       const response = await server.inject({
         method: 'PATCH',
         url: `/api/reports/${report.id}/collection-result`,
+        headers: adminAuthHeader,
         payload: {
           result: 'collected',
         },
       });
 
-      expect(response.statusCode).toBe(400);
+      expect(response.statusCode).toBe(409);
       expect(JSON.parse(response.payload)).toEqual({ error: 'report is not eligible for collection result' });
       expect(prismaBundle.state.reports.get(report.id)!.status).toBe(status);
     }
@@ -479,12 +531,13 @@ describe('reports', () => {
     const response = await server.inject({
       method: 'PATCH',
       url: `/api/reports/${report.id}/collection-result`,
+      headers: adminAuthHeader,
       payload: {
         result: 'collected',
       },
     });
 
-    expect(response.statusCode).toBe(400);
+    expect(response.statusCode).toBe(409);
     expect(JSON.parse(response.payload)).toEqual({ error: 'pending collection request not found' });
     expect(prismaBundle.state.reports.get(report.id)!.status).toBe('collection_requested');
   });
@@ -531,7 +584,7 @@ describe('reports', () => {
         result: 'collected',
         resultRecordedBy: '北区 回収業者',
       })
-    ).rejects.toBeInstanceOf(BadRequestError);
+    ).rejects.toBeInstanceOf(ConflictError);
 
     const collectionRequest = Array.from(isolatedPrismaBundle.state.collectionRequests.values())[0];
     expect(isolatedPrismaBundle.state.reports.get(report.id)!.status).toBe('reported');
@@ -550,6 +603,7 @@ describe('reports', () => {
     const response = await server.inject({
       method: 'POST',
       url: '/api/reports',
+      headers: adminAuthHeader,
       payload: {
         imageUrl: 'https://example.com/report-2.jpg',
         latitude: 34.70,
@@ -573,6 +627,7 @@ describe('reports', () => {
     const response = await server.inject({
       method: 'POST',
       url: '/api/reports',
+      headers: adminAuthHeader,
       payload: {
         latitude: 34.7055,
         longitude: 135.4983,
@@ -589,6 +644,7 @@ describe('reports', () => {
     const response = await server.inject({
       method: 'POST',
       url: '/api/reports',
+      headers: adminAuthHeader,
       payload: {
         imageUrl: 'https://example.com/report-invalid.jpg',
         latitude: '34.7055',
@@ -606,6 +662,7 @@ describe('reports', () => {
     const response = await server.inject({
       method: 'POST',
       url: '/api/reports',
+      headers: adminAuthHeader,
       payload: {
         imageUrl: 'https://example.com/report-invalid.jpg',
         latitude: 34.7055,
@@ -622,6 +679,7 @@ describe('reports', () => {
     const response = await server.inject({
       method: 'POST',
       url: '/api/reports',
+      headers: adminAuthHeader,
       payload: {
         imageUrl: 'https://example.com/report-invalid.jpg',
         latitude: 34.7055,
@@ -632,5 +690,75 @@ describe('reports', () => {
 
     expect(response.statusCode).toBe(400);
     expect(JSON.parse(response.payload)).toEqual({ error: 'identifierText required' });
+  });
+
+  it('rejects report API access without authentication', async () => {
+    const response = await server.inject({
+      method: 'GET',
+      url: '/api/reports',
+    });
+
+    expect(response.statusCode).toBe(401);
+    expect(JSON.parse(response.payload)).toEqual({ error: 'Unauthorized' });
+  });
+
+  it('rejects report API access for non-admin users', async () => {
+    const response = await server.inject({
+      method: 'GET',
+      url: '/api/reports',
+      headers: userAuthHeader,
+    });
+
+    expect(response.statusCode).toBe(403);
+    expect(JSON.parse(response.payload)).toEqual({ error: 'Forbidden' });
+  });
+
+  it('rejects invalid report status filter', async () => {
+    const response = await server.inject({
+      method: 'GET',
+      url: '/api/reports?status=invalid-status',
+      headers: adminAuthHeader,
+    });
+
+    expect(response.statusCode).toBe(400);
+    expect(JSON.parse(response.payload)).toEqual({ error: 'status must be a valid report status' });
+  });
+
+  it('rejects blank required report fields', async () => {
+    const response = await server.inject({
+      method: 'POST',
+      url: '/api/reports',
+      headers: adminAuthHeader,
+      payload: {
+        imageUrl: '   ',
+        latitude: 34.7055,
+        longitude: 135.4983,
+        markerCode: '   ',
+        identifierText: '   ',
+      },
+    });
+
+    expect(response.statusCode).toBe(400);
+    expect(JSON.parse(response.payload)).toEqual({ error: 'imageUrl required' });
+  });
+
+  it('rejects out-of-range coordinates', async () => {
+    const response = await server.inject({
+      method: 'POST',
+      url: '/api/reports',
+      headers: adminAuthHeader,
+      payload: {
+        imageUrl: 'https://example.com/report-invalid-coordinate.jpg',
+        latitude: 91,
+        longitude: 135.4983,
+        markerCode: 'INVALID-COORDINATE-001',
+        identifierText: 'OSAKA-COORD-001',
+      },
+    });
+
+    expect(response.statusCode).toBe(400);
+    expect(JSON.parse(response.payload)).toEqual({
+      error: 'latitude and longitude must be valid coordinates',
+    });
   });
 });

--- a/docs/api/api-spec.md
+++ b/docs/api/api-spec.md
@@ -33,6 +33,7 @@
 ### POST /api/reports
 
 - 説明: サポーターが放置自転車通報を作成
+- 認証: JWT 必須、`admin` ロールのみ
 - Body (JSON):
   - `imageUrl`: string
   - `latitude`: number
@@ -42,7 +43,8 @@
   - `notes`?: string
 - レスポンス: 作成した `report` オブジェクト
 - 実装方針:
-  - `markerCode` は必須
+  - `imageUrl`、`markerCode`、`identifierText` は空文字不可
+  - `latitude` / `longitude` は finite number かつ緯度経度の範囲内であること
   - 該当マーカーが存在しない場合は backend 側で新規作成して紐づける
   - 初期 `status` は `reported`
   - `GOOGLE_MAPS_API_KEY` が設定されている場合は、`latitude` / `longitude` から Google Geocoding API で住所を取得し、`address` に保存する
@@ -77,14 +79,16 @@
 ### GET /api/reports
 
 - 説明: 通報一覧（管理者向け、フィルタあり）
+- 認証: JWT 必須、`admin` ロールのみ
 - Query:
-  - `status` (optional)
+  - `status` (optional, `reported|temporary|resolved|collection_requested|collected|not_found_on_collection`)
 - レスポンス: `[{ report }]`
 - 備考: `report.address` が存在する場合、管理画面は住所を優先表示する。未設定時は座標表示にフォールバックする。
 
 ### GET /api/reports/:id
 
 - 説明: 通報詳細
+- 認証: JWT 必須、`admin` ロールのみ
 - レスポンス: `report`。位置情報として `latitude`, `longitude`, `address` を含む。
 
 ### PATCH /api/reports/:id/status
@@ -95,18 +99,22 @@
 ### POST /api/reports/:id/collection-request
 
 - 説明: 一定時間内に持ち主による解除が行われなかった通報を、管理者が回収依頼対象にする
+- 認証: JWT 必須、`admin` ロールのみ
 - Body: `{ "notes"?: string, "requestedBy"?: string }`
 - 期待挙動:
   - report.status を `collection_requested` に更新する
   - 回収依頼の操作履歴を保存する
+  - 対象が `reported` 以外の場合は `409`
 
 ### PATCH /api/reports/:id/collection-result
 
 - 説明: 回収業者の現地結果を受けて、管理者が回収結果を記録する
+- 認証: JWT 必須、`admin` ロールのみ
 - Body: `{ "result": "collected|not_found_on_collection", "notes"?: string, "resultRecordedBy"?: string }`
 - 期待挙動:
   - `collected`: 回収完了として案件を閉じる
   - `not_found_on_collection`: 現地で現物なしとして未回収記録を残す
+  - 対象が `collection_requested` 以外、または pending 履歴がない場合は `409`
 
 ### GET /api/admin/hotspots（将来構想）
 
@@ -136,6 +144,7 @@
 
 - 説明: 管理者/サポーターのログイン
 - Body: `{ "email": string, "password": string }`
+- バリデーション: `email` と `password` は空文字不可、`email` は最低限の email 形式必須
 - レスポンス: `{ "status": "ok", "data": { "token": "<jwt>" }, "error": null }`
 
 ---
@@ -160,12 +169,20 @@
 
 - 説明: 持ち主が仮解除を実行
 - Body: `{ "notes"?: string }`
+- バリデーション: `code` は空文字不可
 
 ### POST /api/owner/markers/:code/unlock-final
 
 - 説明: 持ち主が本解除を実行（`eligibleFinalAt` 到達後）
 - Body: `{ "scannedCode": string, "ownerEmail"?: string }`
-- 備考: `scannedCode` は必須。QR再スキャン照合で `:code` と一致した場合のみ本解除される。クーポン発行処理は backend に実装されているが、試作品の必須要件には含めない。
+- バリデーション:
+  - `code` と `scannedCode` は空文字不可
+  - `ownerEmail` を送る場合は最低限の email 形式必須
+- 備考:
+  - `scannedCode` は必須。QR再スキャン照合で `:code` と一致した場合のみ本解除される
+  - marker が存在しない場合は `404`
+  - 仮解除なし、`eligibleFinalAt` 未到達、24時間期限切れは `409`
+  - クーポン発行処理は backend に実装されているが、試作品の必須要件には含めない
 
 ### POST /api/owner/coupons/:id/use（実装済み・将来拡張）
 
@@ -208,9 +225,9 @@
 
 - 400: リクエスト不正 (バリデーションエラー)
 - 401: 認証エラー
-- 403: 権限エラー
+- 403: 権限エラー（例: 非 `admin` が `/api/reports*` にアクセス）
 - 404: リソース未検出
-- 409: 状態競合（例: 既に本解除済み）
+- 409: 状態競合（例: 本解除の前提未達、回収依頼/結果記録の対象 status 不一致）
 - 422: 業務ルール違反（ジオフェンス、品質基準未達）
 - 500: サーバー内部エラー
 

--- a/docs/api/openapi-owner.yaml
+++ b/docs/api/openapi-owner.yaml
@@ -73,7 +73,23 @@ paths:
               schema:
                 $ref: '#/components/schemas/FinalizeResponse'
         '400':
-          description: Not eligible yet
+          description: Validation error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '404':
+          description: Marker not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '409':
+          description: Temporary unlock state conflict
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
 components:
   schemas:
     OwnerMarkerResponse:

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -27,6 +27,8 @@ paths:
   /api/reports:
     get:
       summary: 管理画面向け通報一覧
+      security:
+        - bearerAuth: []
       parameters:
         - name: status
           in: query
@@ -42,8 +44,28 @@ paths:
                 type: array
                 items:
                   $ref: "#/components/schemas/BicycleReport"
+        "400":
+          description: Invalid status filter
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
     post:
       summary: Androidアプリから通報を作成
+      security:
+        - bearerAuth: []
       requestBody:
         required: true
         content:
@@ -57,9 +79,29 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/BicycleReport"
+        "400":
+          description: Validation error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
   /api/reports/{id}:
     get:
       summary: 通報詳細
+      security:
+        - bearerAuth: []
       parameters:
         - $ref: "#/components/parameters/ReportId"
       responses:
@@ -69,9 +111,29 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/BicycleReport"
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "404":
+          description: Report not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
   /api/reports/{id}/collection-request:
     post:
       summary: 未解除案件を回収依頼対象にする
+      security:
+        - bearerAuth: []
       parameters:
         - $ref: "#/components/parameters/ReportId"
       requestBody:
@@ -87,9 +149,35 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/BicycleReport"
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "404":
+          description: Report not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "409":
+          description: Report is not eligible for collection request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
   /api/reports/{id}/collection-result:
     patch:
       summary: 回収結果を記録する
+      security:
+        - bearerAuth: []
       parameters:
         - $ref: "#/components/parameters/ReportId"
       requestBody:
@@ -105,6 +193,36 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/BicycleReport"
+        "400":
+          description: Invalid collection result
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "404":
+          description: Report not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "409":
+          description: Report is not eligible for collection result
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
   /api/owner/markers/{code}:
     get:
       summary: 持ち主向けの警告内容取得
@@ -159,7 +277,30 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/UnlockFinalResponse"
+        "400":
+          description: Validation error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "404":
+          description: Marker not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "409":
+          description: Temporary unlock state conflict
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
 components:
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
   parameters:
     ReportId:
       name: id
@@ -194,7 +335,9 @@ components:
     AuthResponse:
       type: object
       properties:
-        token:
+        accessToken:
+          type: string
+        tokenType:
           type: string
     ReportCreate:
       type: object

--- a/plan/2026-05-19__issue-32-validation-error-handling.md
+++ b/plan/2026-05-19__issue-32-validation-error-handling.md
@@ -1,0 +1,50 @@
+# Issue #32: Backend のバリデーションとエラー処理整備
+
+## Goal
+
+- backend の既存 API に対して、入力検証・状態競合・404・権限エラーを整理する。
+- レスポンス形式は既存の `{ error, ...details }` を維持する。
+
+## Non-goals
+
+- `bikes` 系 API への認可追加
+- エラーレスポンスの全面フォーマット刷新
+- `User.role` の enum 化や Prisma schema 変更
+
+## Files And Docs Inspected
+
+- `backend/src/app.ts`
+- `backend/src/lib/errors.ts`
+- `backend/src/routes/*.ts`
+- `backend/src/services/*.ts`
+- `backend/test/*.spec.ts`
+- `docs/api/api-spec.md`
+- `docs/api/openapi.yaml`
+- `docs/api/openapi-owner.yaml`
+- `ARCHITECTURE.md`
+- `AGENTS.md`
+
+## Planned Changes
+
+- `ForbiddenError` と管理 API 用 auth helper を追加し、`/api/reports*` に JWT + admin ロール制御を入れる。
+- `auth` `reports` `owner` `bikes` の入力値を trim 前提で検証し、空文字・形式不正・範囲外を整理する。
+- owner / collection 系の「現在状態では実行不可」を `409` に寄せる。
+- backend の Vitest を更新し、`401/403/400/404/409` の期待値を固定する。
+- API ドキュメントを実装に合わせて更新する。
+
+## Verification
+
+- `cd backend && npm test`
+- `cd backend && npm run build`
+- `git diff --check`
+
+## Assumptions
+
+- 管理 API の対象は `reports` 系のみ。
+- `admin` 以外の role は管理 API にアクセス不可。
+- owner の `unlock-final` で marker 不存在は `404`、`scannedCode` 不一致は `400`、時間・状態競合は `409`。
+
+## Risks And Follow-ups
+
+- `docs/api/*` は `/api/auth/login` と実装の prefix 差分が残っているため、今回の更新では error semantics に集中し、prefix の全面整理は別作業に分離する。
+- durable な運用方針追加が出た場合は `ARCHITECTURE.md` の追記要否を確認する。


### PR DESCRIPTION
## 概要
- backend の入力バリデーションと共通エラー処理を整理
- /api/reports* を JWT + admin ロールで保護し、401/403/409 を明確化
- owner / bikes / auth の境界条件テストと API ドキュメントを更新

## 変更内容
- ForbiddenError と管理 API 用 auth helper を追加
- auth / reports / owner / bikes の入力正規化と検証を追加
- collection 系と owner unlock 系の状態競合を 409 に整理
- backend の Vitest、OpenAPI、API 仕様書、計画ファイルを更新

## 検証
- cd backend && TMPDIR=/tmp npm test
- cd backend && npm run build
- git diff --check

Closes #32