### PR TITLE
Issue 41 通報詳細画面の詳細APIと履歴表示を実装

### DIFF
--- a/apps/admin-dashboard/__tests__/DashboardPages.test.tsx
+++ b/apps/admin-dashboard/__tests__/DashboardPages.test.tsx
@@ -512,6 +512,7 @@ describe('Admin Dashboard pages', () => {
       'src',
       'https://www.google.com/maps/embed/v1/place?key=test&q=34.71%2C135.5',
     );
+    expect(screen.getByText('履歴はありません。')).toBeInTheDocument();
   });
 
   it('fetches report detail by id on the server side', async () => {
@@ -530,6 +531,19 @@ describe('Admin Dashboard pages', () => {
         notes: null,
         createdAt: '2026-04-21T00:30:00.000Z',
         updatedAt: '2026-04-21T00:30:00.000Z',
+        history: [
+          {
+            id: 'h-api-1',
+            timestamp: '2026-04-21T00:30:00.000Z',
+            label: '通報を受付',
+          },
+          {
+            id: 'h-api-2',
+            timestamp: '2026-04-21T02:00:00.000Z',
+            label: '回収依頼を登録',
+            notes: '歩道上に継続駐輪',
+          },
+        ],
       }),
     } as Response);
     global.fetch = fetchMock;
@@ -552,11 +566,68 @@ describe('Admin Dashboard pages', () => {
           address: null,
           mapLinkUrl: 'https://www.google.com/maps?q=34.71%2C135.5',
           status: 'collection_requested',
+          history: [
+            {
+              id: 'h-api-1',
+              timestamp: '2026-04-21 09:30',
+              label: '通報を受付',
+            },
+            {
+              id: 'h-api-2',
+              timestamp: '2026-04-21 11:00',
+              label: '回収依頼を登録',
+              notes: '歩道上に継続駐輪',
+            },
+          ],
         },
       },
     });
 
     global.fetch = originalFetch;
+  });
+
+  it('shows API-backed history notes on the report detail page', () => {
+    useRouter.mockReturnValue({
+      pathname: '/reports/[id]',
+      query: { id: 'r-api-5' },
+      isReady: true,
+    });
+
+    render(
+      <ReportDetailPage
+        report={{
+          id: 'r-api-5',
+          imageUrl: 'https://example.com/report-api-5.jpg',
+          reportedAt: '2026-04-21 08:30',
+          location: '大阪府大阪市北区堂島1丁目',
+          latitude: 34.71,
+          longitude: 135.5,
+          address: '大阪府大阪市北区堂島1丁目',
+          mapEmbedUrl: null,
+          mapLinkUrl: 'https://www.google.com/maps?q=34.71%2C135.5',
+          identifierText: 'API-0005 / 白のミニベロ',
+          status: 'collected',
+          elapsedLabel: '',
+          currentStatusLabel: 'collected',
+          history: [
+            {
+              id: 'h-api-3',
+              timestamp: '2026-04-21 08:30',
+              label: '通報を受付',
+            },
+            {
+              id: 'h-api-4',
+              timestamp: '2026-04-21 11:00',
+              label: '回収結果を記録',
+              notes: '現地で回収完了',
+            },
+          ],
+        }}
+      />,
+    );
+
+    expect(screen.getByText('回収結果を記録')).toBeInTheDocument();
+    expect(screen.getByText('現地で回収完了')).toBeInTheDocument();
   });
 
   it('shows the collection request form and confirmation text', () => {

--- a/apps/admin-dashboard/components/HistoryList.tsx
+++ b/apps/admin-dashboard/components/HistoryList.tsx
@@ -10,17 +10,21 @@ export function HistoryList({ history }: HistoryListProps) {
       <div className="panel-header">
         <h3>履歴</h3>
       </div>
-      <ul className="history-list">
-        {history.map((entry) => (
-          <li key={entry.id}>
-            <div>
-              <strong>{entry.label}</strong>
-              <span>{entry.timestamp}</span>
-            </div>
-            {entry.notes ? <p>{entry.notes}</p> : null}
-          </li>
-        ))}
-      </ul>
+      {history.length === 0 ? (
+        <p>履歴はありません。</p>
+      ) : (
+        <ul className="history-list">
+          {history.map((entry) => (
+            <li key={entry.id}>
+              <div>
+                <strong>{entry.label}</strong>
+                <span>{entry.timestamp}</span>
+              </div>
+              {entry.notes ? <p>{entry.notes}</p> : null}
+            </li>
+          ))}
+        </ul>
+      )}
     </section>
   );
 }

--- a/apps/admin-dashboard/lib/adminReports.ts
+++ b/apps/admin-dashboard/lib/adminReports.ts
@@ -1,4 +1,8 @@
-import type { ReportDetail, ReportStatus } from './types';
+import type {
+  ReportDetail,
+  ReportHistoryEntry,
+  ReportStatus,
+} from './types';
 
 export const reportStatusFilters = [
   'reported',
@@ -12,15 +16,29 @@ export const reportStatusFilters = [
 export type ReportStatusFilter = (typeof reportStatusFilters)[number];
 export type SelectedReportStatus = ReportStatusFilter | 'all';
 
-type ApiReport = {
+type ApiReportSummary = {
   id: string;
+  markerId: string;
   imageUrl: string;
   latitude: number;
   longitude: number;
   address?: string | null;
   identifierText: string;
   status: ReportStatus;
+  notes?: string | null;
   createdAt: string;
+  updatedAt: string;
+};
+
+type ApiReportHistoryEntry = {
+  id: string;
+  timestamp: string;
+  label: string;
+  notes?: string | null;
+};
+
+type ApiReportDetail = ApiReportSummary & {
+  history: ApiReportHistoryEntry[];
 };
 
 export function getAdminApiBaseUrl() {
@@ -53,7 +71,7 @@ export function buildReportsUrl(selectedStatus: SelectedReportStatus) {
   return url.toString();
 }
 
-export function mapApiReportToDetail(report: ApiReport): ReportDetail {
+export function mapApiReportSummaryToDetail(report: ApiReportSummary): ReportDetail {
   const location = report.address ?? formatLocation(report.latitude, report.longitude);
 
   return {
@@ -74,6 +92,15 @@ export function mapApiReportToDetail(report: ApiReport): ReportDetail {
   };
 }
 
+export function mapApiReportDetailToDetail(report: ApiReportDetail): ReportDetail {
+  const mappedReport = mapApiReportSummaryToDetail(report);
+
+  return {
+    ...mappedReport,
+    history: report.history.map(mapApiReportHistoryEntry),
+  };
+}
+
 export async function fetchAdminReports(selectedStatus: SelectedReportStatus) {
   const response = await fetch(buildReportsUrl(selectedStatus));
 
@@ -81,8 +108,8 @@ export async function fetchAdminReports(selectedStatus: SelectedReportStatus) {
     throw new Error(`GET /api/reports failed: ${response.status}`);
   }
 
-  const reports = (await response.json()) as ApiReport[];
-  return reports.map(mapApiReportToDetail);
+  const reports = (await response.json()) as ApiReportSummary[];
+  return reports.map(mapApiReportSummaryToDetail);
 }
 
 export async function fetchAdminReport(id: string) {
@@ -94,7 +121,7 @@ export async function fetchAdminReport(id: string) {
     throw new Error(`GET /api/reports/${id} failed: ${response.status}`);
   }
 
-  return mapApiReportToDetail((await response.json()) as ApiReport);
+  return mapApiReportDetailToDetail((await response.json()) as ApiReportDetail);
 }
 
 function formatDateTime(value: string) {
@@ -138,4 +165,13 @@ function buildMapEmbedUrl(latitude: number, longitude: number) {
   url.searchParams.set('key', apiKey);
   url.searchParams.set('q', `${latitude},${longitude}`);
   return url.toString();
+}
+
+function mapApiReportHistoryEntry(entry: ApiReportHistoryEntry): ReportHistoryEntry {
+  return {
+    id: entry.id,
+    timestamp: formatDateTime(entry.timestamp),
+    label: entry.label,
+    ...(entry.notes ? { notes: entry.notes } : {}),
+  };
 }

--- a/backend/src/services/ownerUnlockService.ts
+++ b/backend/src/services/ownerUnlockService.ts
@@ -109,22 +109,8 @@ export class OwnerUnlockService {
 
     return {
       marker: { code: marker.code },
-      report: report
-        ? {
-          id: report.id,
-          status: report.status as any,
-          imageUrl: report.imageUrl,
-          ocr_text: report.identifierText,
-        }
-        : null,
-      declaration: declaration
-        ? {
-          declaredAt: declaration.declaredAt,
-          eligibleFinalAt: declaration.eligibleFinalAt,
-          expiresAt: declaration.expiresAt,
-          status: declaration.status,
-        }
-        : null,
+      report: report ? { ...report } : null,
+      declaration: declaration ? { ...declaration } : null,
     };
   }
 

--- a/backend/src/services/reportService.ts
+++ b/backend/src/services/reportService.ts
@@ -38,6 +38,26 @@ type CollectionRequestRecord = {
   updatedAt: Date;
 };
 
+type DeclarationRecord = {
+  id: string;
+  markerId: string;
+  declaredAt: Date;
+  eligibleFinalAt: Date;
+  expiresAt: Date;
+  finalizedAt: Date | null;
+  status: string;
+  notes: string | null;
+  createdAt: Date;
+  updatedAt: Date;
+};
+
+type ReportHistoryEntry = {
+  id: string;
+  timestamp: string;
+  label: string;
+  notes?: string;
+};
+
 type CollectionResult = 'collected' | 'not_found_on_collection';
 
 type ReportTransactionPrisma = {
@@ -93,6 +113,12 @@ type ReportTransactionPrisma = {
         notes?: string | null;
       };
     }): Promise<CollectionRequestRecord>;
+    findMany(args: {
+      where: {
+        reportId: string;
+      };
+      orderBy?: { requestedAt: 'asc' | 'desc' };
+    }): Promise<CollectionRequestRecord[]>;
     update(args: {
       where: { id: string };
       data: {
@@ -112,6 +138,14 @@ type ReportPrisma = ReportTransactionPrisma & {
       update: { location?: string | null };
       create: { code: string; location?: string | null };
     }): Promise<MarkerRecord>;
+  };
+  declaration: {
+    findMany(args: {
+      where: {
+        markerId: string;
+      };
+      orderBy?: { declaredAt: 'asc' | 'desc' };
+    }): Promise<DeclarationRecord[]>;
   };
   $transaction<T>(fn: (tx: ReportTransactionPrisma) => Promise<T>): Promise<T>;
 };
@@ -137,7 +171,21 @@ export class ReportService {
       throw new NotFoundError('report not found');
     }
 
-    return report;
+    const [declarations, collectionRequests] = await Promise.all([
+      this.prisma.declaration.findMany({
+        where: { markerId: report.markerId },
+        orderBy: { declaredAt: 'asc' },
+      }),
+      this.prisma.collectionRequest.findMany({
+        where: { reportId: report.id },
+        orderBy: { requestedAt: 'asc' },
+      }),
+    ]);
+
+    return {
+      ...report,
+      history: this.buildReportHistory(report, declarations, collectionRequests),
+    };
   }
 
   async createReport(input: {
@@ -339,5 +387,60 @@ export class ReportService {
     } catch (error) {
       return null;
     }
+  }
+
+  private buildReportHistory(
+    report: ReportRecord,
+    declarations: DeclarationRecord[],
+    collectionRequests: CollectionRequestRecord[]
+  ): ReportHistoryEntry[] {
+    const history: ReportHistoryEntry[] = [
+      {
+        id: `${report.id}:reported`,
+        timestamp: report.createdAt.toISOString(),
+        label: '通報を受付',
+      },
+    ];
+
+    for (const declaration of declarations) {
+      history.push({
+        id: `${declaration.id}:temporary`,
+        timestamp: declaration.declaredAt.toISOString(),
+        label: '持ち主が仮解除',
+        ...(declaration.notes ? { notes: declaration.notes } : {}),
+      });
+
+      if (declaration.status === 'resolved' && declaration.finalizedAt) {
+        history.push({
+          id: `${declaration.id}:resolved`,
+          timestamp: declaration.finalizedAt.toISOString(),
+          label: '持ち主が本解除',
+        });
+      }
+    }
+
+    for (const collectionRequest of collectionRequests) {
+      history.push({
+        id: `${collectionRequest.id}:requested`,
+        timestamp: collectionRequest.requestedAt.toISOString(),
+        label: '回収依頼を登録',
+        ...(collectionRequest.notes && collectionRequest.result === 'pending'
+          ? { notes: collectionRequest.notes }
+          : {}),
+      });
+
+      if (collectionRequest.result !== 'pending' && collectionRequest.resultRecordedAt) {
+        history.push({
+          id: `${collectionRequest.id}:result`,
+          timestamp: collectionRequest.resultRecordedAt.toISOString(),
+          label: '回収結果を記録',
+          ...(collectionRequest.notes ? { notes: collectionRequest.notes } : {}),
+        });
+      }
+    }
+
+    return history.sort(
+      (left, right) => new Date(left.timestamp).getTime() - new Date(right.timestamp).getTime()
+    );
   }
 }

--- a/backend/test/helpers/mockPrisma.ts
+++ b/backend/test/helpers/mockPrisma.ts
@@ -451,6 +451,23 @@ export function createMockPrisma() {
         collectionRequests.set(record.id, record);
         return record;
       },
+      findMany: async ({
+        where,
+        orderBy,
+      }: {
+        where: { reportId: string };
+        orderBy?: { requestedAt: 'asc' | 'desc' };
+      }) => {
+        const filtered = Array.from(collectionRequests.values()).filter((entry) => {
+          return entry.reportId === where.reportId;
+        });
+
+        if (orderBy?.requestedAt === 'asc') {
+          return [...filtered].sort((left, right) => left.requestedAt.getTime() - right.requestedAt.getTime());
+        }
+
+        return sortByDateDesc(filtered, (entry) => entry.requestedAt);
+      },
       update: async ({
         where,
         data,
@@ -485,6 +502,23 @@ export function createMockPrisma() {
       },
     },
     declaration: {
+      findMany: async ({
+        where,
+        orderBy,
+      }: {
+        where: { markerId: string };
+        orderBy?: { declaredAt: 'asc' | 'desc' };
+      }) => {
+        const filtered = Array.from(declarations.values()).filter((entry) => {
+          return entry.markerId === where.markerId;
+        });
+
+        if (orderBy?.declaredAt === 'asc') {
+          return [...filtered].sort((left, right) => left.declaredAt.getTime() - right.declaredAt.getTime());
+        }
+
+        return sortByDateDesc(filtered, (entry) => entry.declaredAt);
+      },
       findFirst: async ({
         where,
       }: {

--- a/backend/test/reports.spec.ts
+++ b/backend/test/reports.spec.ts
@@ -240,7 +240,155 @@ describe('reports', () => {
       identifierText: 'LIST-0001',
       status: 'reported',
       address: null,
+      history: [
+        expect.objectContaining({
+          label: '通報を受付',
+        }),
+      ],
     });
+  });
+
+  it('builds declaration history on report detail', async () => {
+    const isolatedPrismaBundle = createMockPrisma();
+    const isolatedServer = buildServer({
+      prisma: isolatedPrismaBundle.prisma as any,
+    });
+
+    const marker = await isolatedPrismaBundle.prisma.marker.create({
+      data: {
+        code: 'DETAIL-MARKER-001',
+      },
+    });
+    const report = await isolatedPrismaBundle.prisma.bicycleReport.create({
+      data: {
+        markerId: marker.id,
+        imageUrl: 'https://example.com/report-detail-1.jpg',
+        latitude: 34.701,
+        longitude: 135.491,
+        identifierText: 'DETAIL-0001',
+        status: 'resolved',
+      },
+    });
+    isolatedPrismaBundle.state.reports.get(report.id)!.createdAt = new Date('2026-04-20T00:00:00.000Z');
+
+    const declaration = await isolatedPrismaBundle.prisma.declaration.create({
+      data: {
+        markerId: marker.id,
+        declaredAt: new Date('2026-04-20T00:15:00.000Z'),
+        eligibleFinalAt: new Date('2026-04-20T00:30:00.000Z'),
+        expiresAt: new Date('2026-04-21T00:15:00.000Z'),
+        status: 'temporary',
+      },
+    });
+
+    await isolatedPrismaBundle.prisma.declaration.update({
+      where: { id: declaration.id },
+      data: {
+        status: 'resolved',
+        finalizedAt: new Date('2026-04-20T00:45:00.000Z'),
+      },
+    });
+
+    const response = await isolatedServer.inject({
+      method: 'GET',
+      url: `/api/reports/${report.id}`,
+      headers: adminAuthHeader,
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(JSON.parse(response.payload)).toMatchObject({
+      id: report.id,
+      status: 'resolved',
+      history: [
+        expect.objectContaining({
+          label: '通報を受付',
+          timestamp: '2026-04-20T00:00:00.000Z',
+        }),
+        expect.objectContaining({
+          label: '持ち主が仮解除',
+          timestamp: '2026-04-20T00:15:00.000Z',
+        }),
+        expect.objectContaining({
+          label: '持ち主が本解除',
+          timestamp: '2026-04-20T00:45:00.000Z',
+        }),
+      ],
+    });
+
+    await isolatedServer.close();
+  });
+
+  it('builds collection request and result history on report detail', async () => {
+    const isolatedPrismaBundle = createMockPrisma();
+    const isolatedServer = buildServer({
+      prisma: isolatedPrismaBundle.prisma as any,
+    });
+
+    const marker = await isolatedPrismaBundle.prisma.marker.create({
+      data: {
+        code: 'DETAIL-MARKER-002',
+      },
+    });
+    const report = await isolatedPrismaBundle.prisma.bicycleReport.create({
+      data: {
+        markerId: marker.id,
+        imageUrl: 'https://example.com/report-detail-2.jpg',
+        latitude: 34.702,
+        longitude: 135.492,
+        identifierText: 'DETAIL-0002',
+        status: 'collected',
+      },
+    });
+    isolatedPrismaBundle.state.reports.get(report.id)!.createdAt = new Date('2026-04-20T01:00:00.000Z');
+
+    const collectionRequest = await isolatedPrismaBundle.prisma.collectionRequest.create({
+      data: {
+        reportId: report.id,
+        requestedAt: new Date('2026-04-20T02:00:00.000Z'),
+        requestedBy: '北区役所 管理担当',
+        result: 'pending',
+        notes: '歩道上のため回収依頼',
+      },
+    });
+
+    await isolatedPrismaBundle.prisma.collectionRequest.update({
+      where: { id: collectionRequest.id },
+      data: {
+        result: 'collected',
+        resultRecordedAt: new Date('2026-04-20T05:00:00.000Z'),
+        resultRecordedBy: '回収業者A',
+        notes: '現地で回収完了',
+      },
+    });
+
+    const response = await isolatedServer.inject({
+      method: 'GET',
+      url: `/api/reports/${report.id}`,
+      headers: adminAuthHeader,
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(JSON.parse(response.payload)).toMatchObject({
+      id: report.id,
+      status: 'collected',
+      history: [
+        expect.objectContaining({
+          label: '通報を受付',
+          timestamp: '2026-04-20T01:00:00.000Z',
+        }),
+        expect.objectContaining({
+          label: '回収依頼を登録',
+          timestamp: '2026-04-20T02:00:00.000Z',
+        }),
+        expect.objectContaining({
+          label: '回収結果を記録',
+          timestamp: '2026-04-20T05:00:00.000Z',
+          notes: '現地で回収完了',
+        }),
+      ],
+    });
+
+    await isolatedServer.close();
   });
 
   it('returns 404 when report id does not exist', async () => {

--- a/docs/api/api-spec.md
+++ b/docs/api/api-spec.md
@@ -89,7 +89,17 @@
 
 - 説明: 通報詳細
 - 認証: JWT 必須、`admin` ロールのみ
-- レスポンス: `report`。位置情報として `latitude`, `longitude`, `address` を含む。
+- レスポンス: `report`。位置情報として `latitude`, `longitude`, `address` を含み、`history[]` を返す。
+- `history[]`:
+  - `id`: 履歴エントリ ID
+  - `timestamp`: 履歴発生時刻（ISO8601）
+  - `label`: 表示用ラベル
+  - `notes` (optional): 補足メモ
+- 備考:
+  - 先頭に `通報を受付` を含む。
+  - `Declaration` 由来で `持ち主が仮解除` / `持ち主が本解除` を best effort で組み立てる。
+  - `CollectionRequest` 由来で `回収依頼を登録` / `回収結果を記録` を組み立てる。
+  - 返却順は時系列昇順。
 
 ### PATCH /api/reports/:id/status
 

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -110,7 +110,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/BicycleReport"
+                $ref: "#/components/schemas/BicycleReportDetail"
         "401":
           description: Unauthorized
           content:
@@ -384,6 +384,28 @@ components:
         updatedAt:
           type: string
           format: date-time
+    ReportHistoryEntry:
+      type: object
+      properties:
+        id:
+          type: string
+        timestamp:
+          type: string
+          format: date-time
+        label:
+          type: string
+        notes:
+          type: string
+          nullable: true
+    BicycleReportDetail:
+      allOf:
+        - $ref: "#/components/schemas/BicycleReport"
+        - type: object
+          properties:
+            history:
+              type: array
+              items:
+                $ref: "#/components/schemas/ReportHistoryEntry"
     CollectionRequestBody:
       type: object
       properties:


### PR DESCRIPTION
## 概要

- Backend の `GET /api/reports/:id` を詳細レスポンス化し、通報受付・解除・回収系の履歴 `history[]` を返すようにしました
- admin-dashboard で詳細 API の履歴を表示し、履歴がない場合の空状態も追加しました
- API 仕様書と OpenAPI を詳細レスポンスに合わせて更新しました
- `GET /api/owner/markers/:code` を docs / Owner Web 契約に合わせ、最新 report / declaration の full response を返すように戻しました

## 変更内容

- `backend/src/services/reportService.ts` で通報詳細の履歴組み立てを実装
- `backend/test/reports.spec.ts` と Prisma モックを更新して詳細 API の履歴テストを追加
- `apps/admin-dashboard/lib/adminReports.ts` で一覧用/詳細用の API 型を分離し、`history[]` を画面表示用に整形
- `apps/admin-dashboard/components/HistoryList.tsx` に空状態を追加
- `docs/api/api-spec.md` と `docs/api/openapi.yaml` を更新

## 確認

- [x] `cd backend && TMPDIR=/tmp npm test -- reports.spec.ts`
- [x] `cd backend && TMPDIR=/tmp npm test -- owner.spec.ts`
- [x] `cd backend && npm run build`
- [x] `cd backend && TMPDIR=/tmp npm test`
- [x] `cd apps/owner-web && TMPDIR=/tmp npm test`
- [x] `cd apps/owner-web && npm run type-check`
- [x] `cd apps/owner-web && npm run build`
- [x] `cd apps/admin-dashboard && TMPDIR=/tmp npm test`
- [x] `cd apps/admin-dashboard && npm run type-check`
- [x] `cd apps/admin-dashboard && npm run lint`
- [x] `cd apps/admin-dashboard && npm run build`

## 補足

- `apps/owner-web` build では [ReportSummary.tsx](/tmp/NO-Houchi-Bicycle-Net-issue-41/apps/owner-web/components/owner/ReportSummary.tsx:35) の `<img>` に対する既知の `@next/next/no-img-element` 警告が出ますが、ビルドは成功しています。

Closes #41
