### PR TITLE
管理画面に認証導線を追加する

### DIFF
--- a/apps/admin-dashboard/__tests__/DashboardPages.test.tsx
+++ b/apps/admin-dashboard/__tests__/DashboardPages.test.tsx
@@ -532,7 +532,7 @@ describe('Admin Dashboard pages', () => {
 
     await waitFor(() =>
       expect(fetchMock).toHaveBeenCalledWith(
-        '/api/session/reports/r-1/collection-candidate',
+        '/api/session/reports/collection-candidate',
         expect.objectContaining({
           method: 'PATCH',
         }),

--- a/apps/admin-dashboard/__tests__/DashboardPages.test.tsx
+++ b/apps/admin-dashboard/__tests__/DashboardPages.test.tsx
@@ -8,6 +8,7 @@ import ReportDetailPage, {
 } from '../pages/reports/[id]';
 import CollectionRequestPage from '../pages/collection-request/[id]';
 import CollectionResultPage from '../pages/collection-result/[id]';
+import LoginPage from '../pages/login';
 
 jest.mock('next/router', () => ({
   useRouter: jest.fn(),
@@ -19,7 +20,7 @@ const { useRouter } = jest.requireMock('next/router') as {
 
 describe('Admin Dashboard pages', () => {
   it('shows report summary and main columns on the report list page', () => {
-    useRouter.mockReturnValue({ pathname: '/', query: {}, isReady: true });
+    useRouter.mockReturnValue({ pathname: '/', query: {}, isReady: true, push: jest.fn() });
 
     render(<HomePage reports={[]} selectedStatus="all" />);
 
@@ -46,7 +47,7 @@ describe('Admin Dashboard pages', () => {
   });
 
   it('shows API report fields on the report list page', () => {
-    useRouter.mockReturnValue({ pathname: '/', query: {}, isReady: true });
+    useRouter.mockReturnValue({ pathname: '/', query: {}, isReady: true, push: jest.fn() });
 
     render(
       <HomePage
@@ -89,6 +90,7 @@ describe('Admin Dashboard pages', () => {
       pathname: '/',
       query: { status: 'temporary' },
       isReady: true,
+      push: jest.fn(),
     });
 
     render(<HomePage reports={[]} selectedStatus="temporary" />);
@@ -103,6 +105,7 @@ describe('Admin Dashboard pages', () => {
       pathname: '/',
       query: { status: 'resolved' },
       isReady: true,
+      push: jest.fn(),
     });
 
     render(<HomePage reports={[]} selectedStatus="resolved" />);
@@ -120,17 +123,27 @@ describe('Admin Dashboard pages', () => {
 
     await getServerSideProps({
       query: { status: 'resolved' },
+      req: {
+        headers: {
+          cookie: 'admin_access_token=test-token',
+        },
+      },
     } as never);
 
     expect(fetchMock).toHaveBeenCalledWith(
       'http://localhost:3000/api/reports?status=resolved',
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          authorization: 'Bearer test-token',
+        }),
+      }),
     );
 
     global.fetch = originalFetch;
   });
 
   it('shows an error when report list API fetch fails', () => {
-    useRouter.mockReturnValue({ pathname: '/', query: {}, isReady: true });
+    useRouter.mockReturnValue({ pathname: '/', query: {}, isReady: true, push: jest.fn() });
 
     render(
       <HomePage
@@ -171,10 +184,20 @@ describe('Admin Dashboard pages', () => {
 
     const result = await getServerSideProps({
       query: { status: 'temporary' },
+      req: {
+        headers: {
+          cookie: 'admin_access_token=test-token',
+        },
+      },
     } as never);
 
     expect(fetchMock).toHaveBeenCalledWith(
       'http://localhost:3000/api/reports?status=temporary',
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          authorization: 'Bearer test-token',
+        }),
+      }),
     );
     expect(result).toMatchObject({
       props: {
@@ -197,11 +220,114 @@ describe('Admin Dashboard pages', () => {
     global.fetch = originalFetch;
   });
 
+  it('redirects to login when report list page is accessed without a token', async () => {
+    const result = await getServerSideProps({
+      resolvedUrl: '/',
+      req: { headers: {} },
+    } as never);
+
+    expect(result).toEqual({
+      redirect: {
+        destination: '/login?next=%2F',
+        permanent: false,
+      },
+    });
+  });
+
+  it('shows the login form', () => {
+    useRouter.mockReturnValue({
+      pathname: '/login',
+      query: {},
+      isReady: true,
+      push: jest.fn(),
+    });
+
+    render(<LoginPage nextPath="/unresolved" />);
+
+    expect(screen.getByRole('heading', { level: 1, name: '管理者ログイン' })).toBeInTheDocument();
+    expect(screen.getByLabelText('メールアドレス')).toBeInTheDocument();
+    expect(screen.getByLabelText('パスワード')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'ログイン' })).toBeInTheDocument();
+  });
+
+  it('logs in from the login page and redirects to the next path', async () => {
+    const push = jest.fn();
+    useRouter.mockReturnValue({
+      pathname: '/login',
+      query: { next: '/unresolved' },
+      isReady: true,
+      push,
+    });
+
+    const originalFetch = global.fetch;
+    const fetchMock = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ ok: true }),
+    } as Response);
+    global.fetch = fetchMock;
+
+    render(<LoginPage nextPath="/unresolved" />);
+
+    fireEvent.change(screen.getByLabelText('メールアドレス'), {
+      target: { value: 'admin@example.test' },
+    });
+    fireEvent.change(screen.getByLabelText('パスワード'), {
+      target: { value: 'password123' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'ログイン' }));
+
+    await waitFor(() =>
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/api/session/login',
+        expect.objectContaining({
+          method: 'POST',
+        }),
+      ),
+    );
+    await waitFor(() => expect(push).toHaveBeenCalledWith('/unresolved'));
+
+    global.fetch = originalFetch;
+  });
+
+  it('shows an error on the login page when credentials are invalid', async () => {
+    useRouter.mockReturnValue({
+      pathname: '/login',
+      query: {},
+      isReady: true,
+      push: jest.fn(),
+    });
+
+    const originalFetch = global.fetch;
+    const fetchMock = jest.fn().mockResolvedValue({
+      ok: false,
+      status: 401,
+      json: async () => ({ error: 'invalid credentials' }),
+    } as Response);
+    global.fetch = fetchMock;
+
+    render(<LoginPage />);
+
+    fireEvent.change(screen.getByLabelText('メールアドレス'), {
+      target: { value: 'admin@example.test' },
+    });
+    fireEvent.change(screen.getByLabelText('パスワード'), {
+      target: { value: 'wrong-password' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'ログイン' }));
+
+    expect(
+      await screen.findByText('メールアドレスまたはパスワードが正しくありません。'),
+    ).toBeInTheDocument();
+
+    global.fetch = originalFetch;
+  });
+
   it('shows reported list filters and collection candidate state on the unresolved page', () => {
     useRouter.mockReturnValue({
       pathname: '/unresolved',
       query: {},
       isReady: true,
+      push: jest.fn(),
     });
 
     render(
@@ -270,6 +396,7 @@ describe('Admin Dashboard pages', () => {
       pathname: '/unresolved',
       query: { view: 'candidate' },
       isReady: true,
+      push: jest.fn(),
     });
 
     render(
@@ -330,6 +457,7 @@ describe('Admin Dashboard pages', () => {
       pathname: '/unresolved',
       query: { view: 'candidate' },
       isReady: true,
+      push: jest.fn(),
     });
 
     render(
@@ -349,6 +477,7 @@ describe('Admin Dashboard pages', () => {
       pathname: '/unresolved',
       query: {},
       isReady: true,
+      push: jest.fn(),
     });
 
     const originalFetch = global.fetch;
@@ -403,7 +532,7 @@ describe('Admin Dashboard pages', () => {
 
     await waitFor(() =>
       expect(fetchMock).toHaveBeenCalledWith(
-        'http://localhost:3000/api/reports/r-1/collection-candidate',
+        '/api/session/reports/r-1/collection-candidate',
         expect.objectContaining({
           method: 'PATCH',
         }),
@@ -419,6 +548,7 @@ describe('Admin Dashboard pages', () => {
       pathname: '/unresolved',
       query: { view: 'candidate' },
       isReady: true,
+      push: jest.fn(),
     });
 
     const originalFetch = global.fetch;
@@ -536,11 +666,16 @@ describe('Admin Dashboard pages', () => {
     global.fetch = fetchMock;
 
     const { getServerSideProps } = await import('../pages/unresolved');
-    const result = await getServerSideProps({} as never);
+    const result = await getServerSideProps({
+      req: {
+        headers: {
+          cookie: 'admin_access_token=test-token',
+        },
+      },
+    } as never);
+    const request = fetchMock.mock.calls[0];
 
-    expect(fetchMock).toHaveBeenCalledWith(
-      'http://localhost:3000/api/reports?status=reported',
-    );
+    expect(request[0]).toBe('http://localhost:3000/api/reports?status=reported');
     expect(result).toMatchObject({
       props: {
         selectedView: 'all',
@@ -607,10 +742,20 @@ describe('Admin Dashboard pages', () => {
     const { getServerSideProps } = await import('../pages/unresolved');
     const result = await getServerSideProps({
       query: { view: 'unexpected' },
+      req: {
+        headers: {
+          cookie: 'admin_access_token=test-token',
+        },
+      },
     } as never);
 
     expect(fetchMock).toHaveBeenCalledWith(
       'http://localhost:3000/api/reports?status=reported',
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          authorization: 'Bearer test-token',
+        }),
+      }),
     );
     expect(result).toMatchObject({
       props: {
@@ -654,10 +799,20 @@ describe('Admin Dashboard pages', () => {
     const { getServerSideProps } = await import('../pages/unresolved');
     const result = await getServerSideProps({
       query: { view: 'candidate' },
+      req: {
+        headers: {
+          cookie: 'admin_access_token=test-token',
+        },
+      },
     } as never);
 
     expect(fetchMock).toHaveBeenCalledWith(
       'http://localhost:3000/api/reports?status=reported',
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          authorization: 'Bearer test-token',
+        }),
+      }),
     );
     expect(result).toMatchObject({
       props: {
@@ -675,6 +830,7 @@ describe('Admin Dashboard pages', () => {
       pathname: '/reports/[id]',
       query: { id: 'R-002' },
       isReady: true,
+      push: jest.fn(),
     });
 
     render(
@@ -722,6 +878,7 @@ describe('Admin Dashboard pages', () => {
       pathname: '/reports/[id]',
       query: { id: 'r-api-3' },
       isReady: true,
+      push: jest.fn(),
     });
 
     render(
@@ -793,10 +950,20 @@ describe('Admin Dashboard pages', () => {
 
     const result = await getReportDetailServerSideProps({
       params: { id: 'r-api-4' },
+      req: {
+        headers: {
+          cookie: 'admin_access_token=test-token',
+        },
+      },
     } as never);
 
     expect(fetchMock).toHaveBeenCalledWith(
       'http://localhost:3000/api/reports/r-api-4',
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          authorization: 'Bearer test-token',
+        }),
+      }),
     );
     expect(result).toMatchObject({
       props: {
@@ -829,11 +996,44 @@ describe('Admin Dashboard pages', () => {
     global.fetch = originalFetch;
   });
 
+  it('redirects to login when report detail fetch returns unauthorized', async () => {
+    const originalFetch = global.fetch;
+    const fetchMock = jest.fn().mockResolvedValue({
+      ok: false,
+      status: 401,
+      headers: new Headers(),
+    } as Response);
+    global.fetch = fetchMock;
+
+    const result = await getReportDetailServerSideProps({
+      params: { id: 'r-api-4' },
+      resolvedUrl: '/reports/r-api-4',
+      req: {
+        headers: {
+          cookie: 'admin_access_token=expired-token',
+        },
+      },
+      res: {
+        setHeader: jest.fn(),
+      },
+    } as never);
+
+    expect(result).toEqual({
+      redirect: {
+        destination: '/login?next=%2Freports%2Fr-api-4',
+        permanent: false,
+      },
+    });
+
+    global.fetch = originalFetch;
+  });
+
   it('shows API-backed history notes on the report detail page', () => {
     useRouter.mockReturnValue({
       pathname: '/reports/[id]',
       query: { id: 'r-api-5' },
       isReady: true,
+      push: jest.fn(),
     });
 
     render(
@@ -878,6 +1078,7 @@ describe('Admin Dashboard pages', () => {
       pathname: '/collection-request/[id]',
       query: { id: 'R-001' },
       isReady: true,
+      push: jest.fn(),
     });
 
     render(
@@ -915,6 +1116,7 @@ describe('Admin Dashboard pages', () => {
       pathname: '/collection-result/[id]',
       query: { id: 'R-003' },
       isReady: true,
+      push: jest.fn(),
     });
 
     render(
@@ -952,11 +1154,40 @@ describe('Admin Dashboard pages', () => {
       pathname: '/reports/[id]',
       query: {},
       isReady: false,
+      push: jest.fn(),
     });
 
     render(<ReportDetailPage />);
 
     expect(screen.getByText('読み込み中…')).toBeInTheDocument();
     expect(screen.queryByText('対象の通報が見つかりません。')).not.toBeInTheDocument();
+  });
+
+  it('logs out from the app layout', async () => {
+    const push = jest.fn();
+    useRouter.mockReturnValue({ pathname: '/', query: {}, isReady: true, push });
+
+    const originalFetch = global.fetch;
+    const fetchMock = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ ok: true }),
+    } as Response);
+    global.fetch = fetchMock;
+
+    render(<HomePage reports={[]} selectedStatus="all" />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'ログアウト' }));
+
+    await waitFor(() =>
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/api/session/logout',
+        expect.objectContaining({
+          method: 'POST',
+        }),
+      ),
+    );
+    await waitFor(() => expect(push).toHaveBeenCalledWith('/login'));
+
+    global.fetch = originalFetch;
   });
 });

--- a/apps/admin-dashboard/components/AppLayout.tsx
+++ b/apps/admin-dashboard/components/AppLayout.tsx
@@ -1,6 +1,7 @@
 import Head from 'next/head';
 import Link from 'next/link';
 import { useRouter } from 'next/router';
+import { useState } from 'react';
 import type { PropsWithChildren, ReactNode } from 'react';
 
 interface AppLayoutProps extends PropsWithChildren {
@@ -19,6 +20,20 @@ export function AppLayout({
   children,
 }: AppLayoutProps) {
   const router = useRouter();
+  const [isLoggingOut, setIsLoggingOut] = useState(false);
+
+  async function handleLogout() {
+    setIsLoggingOut(true);
+
+    try {
+      await fetch('/api/session/logout', {
+        method: 'POST',
+      });
+      await router.push('/login');
+    } finally {
+      setIsLoggingOut(false);
+    }
+  }
 
   return (
     <>
@@ -52,7 +67,12 @@ export function AppLayout({
               <p className="eyebrow">運用画面</p>
               <h2>{title}</h2>
             </div>
-            {actions ? <div className="header-actions">{actions}</div> : null}
+            <div className="header-actions">
+              {actions}
+              <button type="button" onClick={handleLogout} disabled={isLoggingOut}>
+                {isLoggingOut ? 'ログアウト中…' : 'ログアウト'}
+              </button>
+            </div>
           </header>
           {children}
         </main>

--- a/apps/admin-dashboard/lib/adminApiConfig.ts
+++ b/apps/admin-dashboard/lib/adminApiConfig.ts
@@ -1,0 +1,7 @@
+export function getAdminApiBaseUrl() {
+  return (
+    process.env.ADMIN_API_BASE_URL ||
+    process.env.NEXT_PUBLIC_API_BASE_URL ||
+    'http://localhost:3000'
+  ).replace(/\/$/, '');
+}

--- a/apps/admin-dashboard/lib/adminReports.ts
+++ b/apps/admin-dashboard/lib/adminReports.ts
@@ -4,6 +4,7 @@ import type {
   ReportHistoryEntry,
   ReportStatus,
 } from './types';
+import { AdminSessionUnauthorizedError } from './adminSession';
 
 export const reportStatusFilters = [
   'reported',
@@ -48,12 +49,45 @@ type ApiReportDetail = ApiReportSummary & {
   history: ApiReportHistoryEntry[];
 };
 
+type FetchInit = NonNullable<Parameters<typeof fetch>[1]>;
+
 export function getAdminApiBaseUrl() {
   return (
     process.env.ADMIN_API_BASE_URL ||
     process.env.NEXT_PUBLIC_API_BASE_URL ||
     'http://localhost:3000'
   ).replace(/\/$/, '');
+}
+
+function buildAuthorizedRequestInit(token?: string, init: FetchInit = {}) {
+  const headers: Record<string, string> = {};
+
+  if (init.headers && !Array.isArray(init.headers) && !(init.headers instanceof Headers)) {
+    Object.assign(headers, init.headers);
+  }
+
+  if (token) {
+    headers.authorization = `Bearer ${token}`;
+  }
+
+  return {
+    ...init,
+    headers,
+  };
+}
+
+async function fetchAdminApiJson<T>(url: string, token?: string, init: FetchInit = {}) {
+  const response = await fetch(url, buildAuthorizedRequestInit(token, init));
+
+  if (response.status === 401 || response.status === 403) {
+    throw new AdminSessionUnauthorizedError();
+  }
+
+  if (!response.ok) {
+    throw new Error(`${init.method ?? 'GET'} ${url} failed: ${response.status}`);
+  }
+
+  return (await response.json()) as T;
 }
 
 export function normalizeSelectedStatus(
@@ -118,41 +152,32 @@ export function mapApiReportDetailToDetail(report: ApiReportDetail): ReportDetai
   };
 }
 
-export async function fetchAdminReports(selectedStatus: SelectedReportStatus) {
-  const response = await fetch(buildReportsUrl(selectedStatus));
-
-  if (!response.ok) {
-    throw new Error(`GET /api/reports failed: ${response.status}`);
-  }
-
-  const reports = (await response.json()) as ApiReportSummary[];
+export async function fetchAdminReports(selectedStatus: SelectedReportStatus, token?: string) {
+  const reports = await fetchAdminApiJson<ApiReportSummary[]>(
+    buildReportsUrl(selectedStatus),
+    token,
+  );
   return reports.map(mapApiReportSummaryToDetail);
 }
 
-export async function fetchReportedCandidateReports(now: Date = new Date()) {
-  const response = await fetch(buildReportsUrl('reported'));
-
-  if (!response.ok) {
-    throw new Error(`GET /api/reports?status=reported failed: ${response.status}`);
-  }
-
-  const reports = (await response.json()) as ApiReportSummary[];
+export async function fetchReportedCandidateReports(now: Date = new Date(), token?: string) {
+  const reports = await fetchAdminApiJson<ApiReportSummary[]>(
+    buildReportsUrl('reported'),
+    token,
+  );
 
   return reports
     .filter((report) => report.status === 'reported')
     .map((report) => mapApiReportSummaryToDetailWithNow(report, now));
 }
 
-export async function fetchAdminReport(id: string) {
-  const response = await fetch(
-    `${getAdminApiBaseUrl()}/api/reports/${encodeURIComponent(id)}`,
+export async function fetchAdminReport(id: string, token?: string) {
+  return mapApiReportDetailToDetail(
+    await fetchAdminApiJson<ApiReportDetail>(
+      `${getAdminApiBaseUrl()}/api/reports/${encodeURIComponent(id)}`,
+      token,
+    ),
   );
-
-  if (!response.ok) {
-    throw new Error(`GET /api/reports/${id} failed: ${response.status}`);
-  }
-
-  return mapApiReportDetailToDetail((await response.json()) as ApiReportDetail);
 }
 
 export async function updateCollectionCandidate(
@@ -160,8 +185,9 @@ export async function updateCollectionCandidate(
   isCollectionCandidate: boolean,
   now: Date = new Date(),
 ) {
-  const response = await fetch(
-    `${getAdminApiBaseUrl()}/api/reports/${encodeURIComponent(id)}/collection-candidate`,
+  const updatedReport = await fetchAdminApiJson<ApiReportSummary>(
+    `/api/session/reports/${encodeURIComponent(id)}/collection-candidate`,
+    undefined,
     {
       method: 'PATCH',
       headers: {
@@ -170,12 +196,7 @@ export async function updateCollectionCandidate(
       body: JSON.stringify({ isCollectionCandidate }),
     },
   );
-
-  if (!response.ok) {
-    throw new Error(`PATCH /api/reports/${id}/collection-candidate failed: ${response.status}`);
-  }
-
-  return mapApiReportSummaryToDetailWithNow((await response.json()) as ApiReportSummary, now);
+  return mapApiReportSummaryToDetailWithNow(updatedReport, now);
 }
 
 export function normalizeSelectedUnresolvedView(

--- a/apps/admin-dashboard/lib/adminReports.ts
+++ b/apps/admin-dashboard/lib/adminReports.ts
@@ -4,7 +4,8 @@ import type {
   ReportHistoryEntry,
   ReportStatus,
 } from './types';
-import { AdminSessionUnauthorizedError } from './adminSession';
+import { getAdminApiBaseUrl } from './adminApiConfig';
+import { AdminSessionUnauthorizedError } from './adminSessionShared';
 
 export const reportStatusFilters = [
   'reported',
@@ -50,14 +51,6 @@ type ApiReportDetail = ApiReportSummary & {
 };
 
 type FetchInit = NonNullable<Parameters<typeof fetch>[1]>;
-
-export function getAdminApiBaseUrl() {
-  return (
-    process.env.ADMIN_API_BASE_URL ||
-    process.env.NEXT_PUBLIC_API_BASE_URL ||
-    'http://localhost:3000'
-  ).replace(/\/$/, '');
-}
 
 function buildAuthorizedRequestInit(token?: string, init: FetchInit = {}) {
   const headers: Record<string, string> = {};
@@ -186,14 +179,14 @@ export async function updateCollectionCandidate(
   now: Date = new Date(),
 ) {
   const updatedReport = await fetchAdminApiJson<ApiReportSummary>(
-    `/api/session/reports/${encodeURIComponent(id)}/collection-candidate`,
+    `/api/session/reports/collection-candidate`,
     undefined,
     {
       method: 'PATCH',
       headers: {
         'content-type': 'application/json',
       },
-      body: JSON.stringify({ isCollectionCandidate }),
+      body: JSON.stringify({ id, isCollectionCandidate }),
     },
   );
   return mapApiReportSummaryToDetailWithNow(updatedReport, now);

--- a/apps/admin-dashboard/lib/adminSession.ts
+++ b/apps/admin-dashboard/lib/adminSession.ts
@@ -3,61 +3,12 @@ import type {
   GetServerSidePropsResult,
 } from 'next';
 import type { ServerResponse } from 'http';
-
-export const ADMIN_SESSION_COOKIE_NAME = 'admin_access_token';
-
-export class AdminSessionUnauthorizedError extends Error {
-  constructor(message = 'Unauthorized') {
-    super(message);
-    this.name = 'AdminSessionUnauthorizedError';
-  }
-}
-
-export function parseCookieHeader(cookieHeader?: string) {
-  if (!cookieHeader) {
-    return {} as Record<string, string>;
-  }
-
-  return cookieHeader.split(';').reduce<Record<string, string>>((cookies, part) => {
-    const [rawName, ...rawValue] = part.trim().split('=');
-
-    if (!rawName) {
-      return cookies;
-    }
-
-    cookies[rawName] = decodeURIComponent(rawValue.join('='));
-    return cookies;
-  }, {});
-}
-
-export function getAdminSessionToken(cookieHeader?: string) {
-  return parseCookieHeader(cookieHeader)[ADMIN_SESSION_COOKIE_NAME];
-}
-
-export function createAdminSessionCookie(token: string) {
-  return [
-    `${ADMIN_SESSION_COOKIE_NAME}=${encodeURIComponent(token)}`,
-    'Path=/',
-    'HttpOnly',
-    'SameSite=Lax',
-    process.env.NODE_ENV === 'production' ? 'Secure' : null,
-  ]
-    .filter(Boolean)
-    .join('; ');
-}
-
-export function clearAdminSessionCookie() {
-  return [
-    `${ADMIN_SESSION_COOKIE_NAME}=`,
-    'Path=/',
-    'HttpOnly',
-    'SameSite=Lax',
-    'Max-Age=0',
-    process.env.NODE_ENV === 'production' ? 'Secure' : null,
-  ]
-    .filter(Boolean)
-    .join('; ');
-}
+import {
+  AdminSessionUnauthorizedError,
+  buildLoginRedirectDestination,
+  clearAdminSessionCookie,
+  getAdminSessionToken,
+} from './adminSessionShared';
 
 export function appendResponseCookie(res: ServerResponse, cookieValue: string) {
   const current = typeof res.getHeader === 'function' ? res.getHeader('Set-Cookie') : undefined;
@@ -71,22 +22,9 @@ export function appendResponseCookie(res: ServerResponse, cookieValue: string) {
   res.setHeader('Set-Cookie', [...values, cookieValue]);
 }
 
-export function normalizeNextPath(value: string | string[] | undefined) {
-  const path = Array.isArray(value) ? value[0] : value;
-
-  if (!path || !path.startsWith('/') || path.startsWith('//')) {
-    return '/';
-  }
-
-  return path;
-}
-
-export function buildLoginRedirectDestination(path: string) {
-  return `/login?next=${encodeURIComponent(normalizeNextPath(path))}`;
-}
-
 export function getRequestPath(context: GetServerSidePropsContext) {
-  return normalizeNextPath(context.resolvedUrl || context.req.url || '/');
+  const path = context.resolvedUrl || context.req.url || '/';
+  return path.startsWith('/') ? path : '/';
 }
 
 export function redirectToLogin(context: GetServerSidePropsContext) {

--- a/apps/admin-dashboard/lib/adminSession.ts
+++ b/apps/admin-dashboard/lib/adminSession.ts
@@ -1,0 +1,122 @@
+import type {
+  GetServerSidePropsContext,
+  GetServerSidePropsResult,
+} from 'next';
+import type { ServerResponse } from 'http';
+
+export const ADMIN_SESSION_COOKIE_NAME = 'admin_access_token';
+
+export class AdminSessionUnauthorizedError extends Error {
+  constructor(message = 'Unauthorized') {
+    super(message);
+    this.name = 'AdminSessionUnauthorizedError';
+  }
+}
+
+export function parseCookieHeader(cookieHeader?: string) {
+  if (!cookieHeader) {
+    return {} as Record<string, string>;
+  }
+
+  return cookieHeader.split(';').reduce<Record<string, string>>((cookies, part) => {
+    const [rawName, ...rawValue] = part.trim().split('=');
+
+    if (!rawName) {
+      return cookies;
+    }
+
+    cookies[rawName] = decodeURIComponent(rawValue.join('='));
+    return cookies;
+  }, {});
+}
+
+export function getAdminSessionToken(cookieHeader?: string) {
+  return parseCookieHeader(cookieHeader)[ADMIN_SESSION_COOKIE_NAME];
+}
+
+export function createAdminSessionCookie(token: string) {
+  return [
+    `${ADMIN_SESSION_COOKIE_NAME}=${encodeURIComponent(token)}`,
+    'Path=/',
+    'HttpOnly',
+    'SameSite=Lax',
+    process.env.NODE_ENV === 'production' ? 'Secure' : null,
+  ]
+    .filter(Boolean)
+    .join('; ');
+}
+
+export function clearAdminSessionCookie() {
+  return [
+    `${ADMIN_SESSION_COOKIE_NAME}=`,
+    'Path=/',
+    'HttpOnly',
+    'SameSite=Lax',
+    'Max-Age=0',
+    process.env.NODE_ENV === 'production' ? 'Secure' : null,
+  ]
+    .filter(Boolean)
+    .join('; ');
+}
+
+export function appendResponseCookie(res: ServerResponse, cookieValue: string) {
+  const current = typeof res.getHeader === 'function' ? res.getHeader('Set-Cookie') : undefined;
+
+  if (!current) {
+    res.setHeader('Set-Cookie', cookieValue);
+    return;
+  }
+
+  const values = Array.isArray(current) ? current : [String(current)];
+  res.setHeader('Set-Cookie', [...values, cookieValue]);
+}
+
+export function normalizeNextPath(value: string | string[] | undefined) {
+  const path = Array.isArray(value) ? value[0] : value;
+
+  if (!path || !path.startsWith('/') || path.startsWith('//')) {
+    return '/';
+  }
+
+  return path;
+}
+
+export function buildLoginRedirectDestination(path: string) {
+  return `/login?next=${encodeURIComponent(normalizeNextPath(path))}`;
+}
+
+export function getRequestPath(context: GetServerSidePropsContext) {
+  return normalizeNextPath(context.resolvedUrl || context.req.url || '/');
+}
+
+export function redirectToLogin(context: GetServerSidePropsContext) {
+  return {
+    redirect: {
+      destination: buildLoginRedirectDestination(getRequestPath(context)),
+      permanent: false,
+    },
+  };
+}
+
+export async function withAdminPageAuth<T>(
+  context: GetServerSidePropsContext,
+  // eslint-disable-next-line no-unused-vars
+  loader: (token: string) => Promise<GetServerSidePropsResult<T>>,
+): Promise<GetServerSidePropsResult<T>> {
+  const token = getAdminSessionToken(context.req?.headers?.cookie);
+
+  if (!token) {
+    return redirectToLogin(context);
+  }
+
+  try {
+    return await loader(token);
+  } catch (error) {
+    if (error instanceof AdminSessionUnauthorizedError) {
+      appendResponseCookie(context.res, clearAdminSessionCookie());
+      return redirectToLogin(context);
+    }
+
+    throw error;
+  }
+}

--- a/apps/admin-dashboard/lib/adminSessionShared.ts
+++ b/apps/admin-dashboard/lib/adminSessionShared.ts
@@ -1,0 +1,69 @@
+export const ADMIN_SESSION_COOKIE_NAME = 'admin_access_token';
+
+export class AdminSessionUnauthorizedError extends Error {
+  constructor(message = 'Unauthorized') {
+    super(message);
+    this.name = 'AdminSessionUnauthorizedError';
+  }
+}
+
+export function parseCookieHeader(cookieHeader?: string) {
+  if (!cookieHeader) {
+    return {} as Record<string, string>;
+  }
+
+  return cookieHeader.split(';').reduce<Record<string, string>>((cookies, part) => {
+    const [rawName, ...rawValue] = part.trim().split('=');
+
+    if (!rawName) {
+      return cookies;
+    }
+
+    cookies[rawName] = decodeURIComponent(rawValue.join('='));
+    return cookies;
+  }, {});
+}
+
+export function getAdminSessionToken(cookieHeader?: string) {
+  return parseCookieHeader(cookieHeader)[ADMIN_SESSION_COOKIE_NAME];
+}
+
+export function createAdminSessionCookie(token: string) {
+  return [
+    `${ADMIN_SESSION_COOKIE_NAME}=${encodeURIComponent(token)}`,
+    'Path=/',
+    'HttpOnly',
+    'SameSite=Lax',
+    process.env.NODE_ENV === 'production' ? 'Secure' : null,
+  ]
+    .filter(Boolean)
+    .join('; ');
+}
+
+export function clearAdminSessionCookie() {
+  return [
+    `${ADMIN_SESSION_COOKIE_NAME}=`,
+    'Path=/',
+    'HttpOnly',
+    'SameSite=Lax',
+    'Max-Age=0',
+    process.env.NODE_ENV === 'production' ? 'Secure' : null,
+  ]
+    .filter(Boolean)
+    .join('; ');
+}
+
+export function normalizeNextPath(value: string | string[] | undefined) {
+  const path = Array.isArray(value) ? value[0] : value;
+
+  if (!path || !path.startsWith('/') || path.startsWith('//')) {
+    return '/';
+  }
+
+  return path;
+}
+
+export function buildLoginRedirectDestination(path: string) {
+  return `/login?next=${encodeURIComponent(normalizeNextPath(path))}`;
+}
+

--- a/apps/admin-dashboard/pages/api/session/login.ts
+++ b/apps/admin-dashboard/pages/api/session/login.ts
@@ -1,0 +1,46 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { createAdminSessionCookie, normalizeNextPath } from '../../../lib/adminSession';
+import { getAdminApiBaseUrl } from '../../../lib/adminReports';
+
+type LoginResponse = {
+  ok?: boolean;
+  error?: string;
+  redirectTo?: string;
+};
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<LoginResponse>,
+) {
+  if (req.method !== 'POST') {
+    res.setHeader('Allow', 'POST');
+    return res.status(405).json({ error: 'Method Not Allowed' });
+  }
+
+  const response = await fetch(`${getAdminApiBaseUrl()}/api/auth/login`, {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json',
+    },
+    body: JSON.stringify({
+      email: req.body?.email,
+      password: req.body?.password,
+    }),
+  });
+
+  const payload = (await response.json().catch(() => null)) as
+    | { accessToken?: string; error?: string }
+    | null;
+
+  if (!response.ok || !payload?.accessToken) {
+    return res.status(response.status || 500).json({
+      error: payload?.error ?? 'login failed',
+    });
+  }
+
+  res.setHeader('Set-Cookie', createAdminSessionCookie(payload.accessToken));
+  return res.status(200).json({
+    ok: true,
+    redirectTo: normalizeNextPath(req.body?.next),
+  });
+}

--- a/apps/admin-dashboard/pages/api/session/login.ts
+++ b/apps/admin-dashboard/pages/api/session/login.ts
@@ -1,6 +1,6 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
-import { createAdminSessionCookie, normalizeNextPath } from '../../../lib/adminSession';
-import { getAdminApiBaseUrl } from '../../../lib/adminReports';
+import { getAdminApiBaseUrl } from '../../../lib/adminApiConfig';
+import { createAdminSessionCookie, normalizeNextPath } from '../../../lib/adminSessionShared';
 
 type LoginResponse = {
   ok?: boolean;

--- a/apps/admin-dashboard/pages/api/session/logout.ts
+++ b/apps/admin-dashboard/pages/api/session/logout.ts
@@ -1,5 +1,5 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
-import { clearAdminSessionCookie } from '../../../lib/adminSession';
+import { clearAdminSessionCookie } from '../../../lib/adminSessionShared';
 
 export default function handler(
   req: NextApiRequest,

--- a/apps/admin-dashboard/pages/api/session/logout.ts
+++ b/apps/admin-dashboard/pages/api/session/logout.ts
@@ -1,0 +1,15 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { clearAdminSessionCookie } from '../../../lib/adminSession';
+
+export default function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<{ ok?: boolean; error?: string }>,
+) {
+  if (req.method !== 'POST') {
+    res.setHeader('Allow', 'POST');
+    return res.status(405).json({ error: 'Method Not Allowed' });
+  }
+
+  res.setHeader('Set-Cookie', clearAdminSessionCookie());
+  return res.status(200).json({ ok: true });
+}

--- a/apps/admin-dashboard/pages/api/session/reports/[id]/collection-candidate.ts
+++ b/apps/admin-dashboard/pages/api/session/reports/[id]/collection-candidate.ts
@@ -1,0 +1,51 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import {
+  AdminSessionUnauthorizedError,
+  appendResponseCookie,
+  clearAdminSessionCookie,
+  getAdminSessionToken,
+} from '../../../../../lib/adminSession';
+import { getAdminApiBaseUrl } from '../../../../../lib/adminReports';
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'PATCH') {
+    res.setHeader('Allow', 'PATCH');
+    return res.status(405).json({ error: 'Method Not Allowed' });
+  }
+
+  const token = getAdminSessionToken(req.headers.cookie);
+
+  if (!token) {
+    return res.status(401).json({ error: 'Unauthorized' });
+  }
+
+  try {
+    const response = await fetch(
+      `${getAdminApiBaseUrl()}/api/reports/${encodeURIComponent(String(req.query.id))}/collection-candidate`,
+      {
+        method: 'PATCH',
+        headers: {
+          authorization: `Bearer ${token}`,
+          'content-type': 'application/json',
+        },
+        body: JSON.stringify({
+          isCollectionCandidate: req.body?.isCollectionCandidate,
+        }),
+      },
+    );
+
+    if (response.status === 401 || response.status === 403) {
+      throw new AdminSessionUnauthorizedError();
+    }
+
+    const payload = await response.json().catch(() => null);
+    return res.status(response.status).json(payload);
+  } catch (error) {
+    if (error instanceof AdminSessionUnauthorizedError) {
+      appendResponseCookie(res, clearAdminSessionCookie());
+      return res.status(401).json({ error: 'Unauthorized' });
+    }
+
+    return res.status(500).json({ error: 'Backend request failed' });
+  }
+}

--- a/apps/admin-dashboard/pages/api/session/reports/collection-candidate.ts
+++ b/apps/admin-dashboard/pages/api/session/reports/collection-candidate.ts
@@ -1,11 +1,10 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
+import { getAdminApiBaseUrl } from '../../../../lib/adminApiConfig';
 import {
   AdminSessionUnauthorizedError,
-  appendResponseCookie,
   clearAdminSessionCookie,
   getAdminSessionToken,
-} from '../../../../../lib/adminSession';
-import { getAdminApiBaseUrl } from '../../../../../lib/adminReports';
+} from '../../../../lib/adminSessionShared';
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   if (req.method !== 'PATCH') {
@@ -14,14 +13,19 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
   }
 
   const token = getAdminSessionToken(req.headers.cookie);
+  const id = typeof req.body?.id === 'string' ? req.body.id : undefined;
 
   if (!token) {
     return res.status(401).json({ error: 'Unauthorized' });
   }
 
+  if (!id) {
+    return res.status(400).json({ error: 'report id required' });
+  }
+
   try {
     const response = await fetch(
-      `${getAdminApiBaseUrl()}/api/reports/${encodeURIComponent(String(req.query.id))}/collection-candidate`,
+      `${getAdminApiBaseUrl()}/api/reports/${encodeURIComponent(id)}/collection-candidate`,
       {
         method: 'PATCH',
         headers: {
@@ -42,7 +46,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     return res.status(response.status).json(payload);
   } catch (error) {
     if (error instanceof AdminSessionUnauthorizedError) {
-      appendResponseCookie(res, clearAdminSessionCookie());
+      res.setHeader('Set-Cookie', clearAdminSessionCookie());
       return res.status(401).json({ error: 'Unauthorized' });
     }
 

--- a/apps/admin-dashboard/pages/collection-request/[id].tsx
+++ b/apps/admin-dashboard/pages/collection-request/[id].tsx
@@ -5,6 +5,7 @@ import { AppLayout } from '../../components/AppLayout';
 import { DetailCard } from '../../components/DetailCard';
 import { FormScaffold } from '../../components/FormScaffold';
 import { fetchAdminReport } from '../../lib/adminReports';
+import { withAdminPageAuth } from '../../lib/adminSession';
 import type { ReportDetail } from '../../lib/types';
 
 type CollectionRequestPageProps = {
@@ -78,6 +79,7 @@ export default function CollectionRequestPage({
 
 export const getServerSideProps: GetServerSideProps<CollectionRequestPageProps> = async ({
   params,
+  ...context
 }) => {
   const id = typeof params?.id === 'string' ? params.id : undefined;
 
@@ -89,20 +91,31 @@ export const getServerSideProps: GetServerSideProps<CollectionRequestPageProps> 
     };
   }
 
-  try {
-    const report = await fetchAdminReport(id);
+  return withAdminPageAuth<CollectionRequestPageProps>(
+    {
+      params,
+      ...context,
+    } as never,
+    async (token) => {
+      try {
+        const report = await fetchAdminReport(id, token);
 
-    return {
-      props: {
-        report,
-      },
-    };
-  } catch (error) {
-    return {
-      props: {
-        errorMessage:
-          '回収依頼対象を取得できませんでした。Backend API の起動状態を確認してください。',
-      },
-    };
-  }
+        return {
+          props: {
+            report,
+          },
+        };
+      } catch (error) {
+        if (error instanceof Error && error.name === 'AdminSessionUnauthorizedError') {
+          throw error;
+        }
+        return {
+          props: {
+            errorMessage:
+              '回収依頼対象を取得できませんでした。Backend API の起動状態を確認してください。',
+          },
+        };
+      }
+    },
+  );
 };

--- a/apps/admin-dashboard/pages/collection-result/[id].tsx
+++ b/apps/admin-dashboard/pages/collection-result/[id].tsx
@@ -5,6 +5,7 @@ import { AppLayout } from '../../components/AppLayout';
 import { DetailCard } from '../../components/DetailCard';
 import { FormScaffold } from '../../components/FormScaffold';
 import { fetchAdminReport } from '../../lib/adminReports';
+import { withAdminPageAuth } from '../../lib/adminSession';
 import type { ReportDetail } from '../../lib/types';
 
 type CollectionResultPageProps = {
@@ -104,6 +105,7 @@ export default function CollectionResultPage({
 
 export const getServerSideProps: GetServerSideProps<CollectionResultPageProps> = async ({
   params,
+  ...context
 }) => {
   const id = typeof params?.id === 'string' ? params.id : undefined;
 
@@ -115,20 +117,31 @@ export const getServerSideProps: GetServerSideProps<CollectionResultPageProps> =
     };
   }
 
-  try {
-    const report = await fetchAdminReport(id);
+  return withAdminPageAuth<CollectionResultPageProps>(
+    {
+      params,
+      ...context,
+    } as never,
+    async (token) => {
+      try {
+        const report = await fetchAdminReport(id, token);
 
-    return {
-      props: {
-        report,
-      },
-    };
-  } catch (error) {
-    return {
-      props: {
-        errorMessage:
-          '回収結果対象を取得できませんでした。Backend API の起動状態を確認してください。',
-      },
-    };
-  }
+        return {
+          props: {
+            report,
+          },
+        };
+      } catch (error) {
+        if (error instanceof Error && error.name === 'AdminSessionUnauthorizedError') {
+          throw error;
+        }
+        return {
+          props: {
+            errorMessage:
+              '回収結果対象を取得できませんでした。Backend API の起動状態を確認してください。',
+          },
+        };
+      }
+    },
+  );
 };

--- a/apps/admin-dashboard/pages/index.tsx
+++ b/apps/admin-dashboard/pages/index.tsx
@@ -9,6 +9,7 @@ import {
   reportStatusFilters,
   type SelectedReportStatus,
 } from '../lib/adminReports';
+import { withAdminPageAuth } from '../lib/adminSession';
 import type { ReportDetail } from '../lib/types';
 
 type HomePageProps = {
@@ -68,27 +69,39 @@ export default function HomePage({
 }
 
 export const getServerSideProps: GetServerSideProps<HomePageProps> = async ({
-  query,
+  query = {},
+  ...context
 }) => {
   const selectedStatus = normalizeSelectedStatus(query.status);
 
-  try {
-    const reports = await fetchAdminReports(selectedStatus);
+  return withAdminPageAuth<HomePageProps>(
+    {
+      query,
+      ...context,
+    } as never,
+    async (token) => {
+      try {
+        const reports = await fetchAdminReports(selectedStatus, token);
 
-    return {
-      props: {
-        reports,
-        selectedStatus,
-      },
-    };
-  } catch (error) {
-    return {
-      props: {
-        reports: [],
-        selectedStatus,
-        errorMessage:
-          '通報一覧を取得できませんでした。Backend API の起動状態を確認してください。',
-      },
-    };
-  }
+        return {
+          props: {
+            reports,
+            selectedStatus,
+          },
+        };
+      } catch (error) {
+        if (error instanceof Error && error.name === 'AdminSessionUnauthorizedError') {
+          throw error;
+        }
+        return {
+          props: {
+            reports: [],
+            selectedStatus,
+            errorMessage:
+              '通報一覧を取得できませんでした。Backend API の起動状態を確認してください。',
+          },
+        };
+      }
+    },
+  );
 };

--- a/apps/admin-dashboard/pages/login.tsx
+++ b/apps/admin-dashboard/pages/login.tsx
@@ -1,0 +1,117 @@
+import Head from 'next/head';
+import type { GetServerSideProps } from 'next';
+import { useRouter } from 'next/router';
+import type { FormEvent } from 'react';
+import { useState } from 'react';
+import { getAdminSessionToken, normalizeNextPath } from '../lib/adminSession';
+
+type LoginPageProps = {
+  nextPath?: string;
+};
+
+export default function LoginPage({ nextPath = '/' }: LoginPageProps) {
+  const router = useRouter();
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  async function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    setIsSubmitting(true);
+    setErrorMessage(null);
+
+    try {
+      const response = await fetch('/api/session/login', {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+        },
+        body: JSON.stringify({
+          email,
+          password,
+          next: nextPath,
+        }),
+      });
+
+      const payload = (await response.json().catch(() => null)) as
+        | { redirectTo?: string; error?: string }
+        | null;
+
+      if (!response.ok) {
+        setErrorMessage(
+          payload?.error === 'invalid credentials'
+            ? 'メールアドレスまたはパスワードが正しくありません。'
+            : 'ログインに失敗しました。時間を置いて再試行してください。',
+        );
+        return;
+      }
+
+      await router.push(payload?.redirectTo ?? nextPath ?? '/');
+    } finally {
+      setIsSubmitting(false);
+    }
+  }
+
+  return (
+    <>
+      <Head>
+        <title>管理者ログイン | Admin Dashboard</title>
+      </Head>
+      <main className="auth-shell">
+        <section className="auth-card">
+          <p className="eyebrow">NO-Houchi Bicycle Net</p>
+          <h1>管理者ログイン</h1>
+          <p className="panel-meta">管理画面を利用するにはログインが必要です。</p>
+          <form className="auth-form" onSubmit={handleSubmit}>
+            <label className="form-field">
+              <span>メールアドレス</span>
+              <input
+                type="email"
+                value={email}
+                onChange={(event) => setEmail(event.target.value)}
+                autoComplete="username"
+                required
+              />
+            </label>
+            <label className="form-field">
+              <span>パスワード</span>
+              <input
+                type="password"
+                value={password}
+                onChange={(event) => setPassword(event.target.value)}
+                autoComplete="current-password"
+                required
+              />
+            </label>
+            {errorMessage ? (
+              <p className="auth-error" role="alert">
+                {errorMessage}
+              </p>
+            ) : null}
+            <button type="submit" className="button-primary auth-submit" disabled={isSubmitting}>
+              {isSubmitting ? 'ログイン中…' : 'ログイン'}
+            </button>
+          </form>
+        </section>
+      </main>
+    </>
+  );
+}
+
+export const getServerSideProps: GetServerSideProps<LoginPageProps> = async ({ query, req }) => {
+  if (getAdminSessionToken(req.headers.cookie)) {
+    return {
+      redirect: {
+        destination: '/',
+        permanent: false,
+      },
+    };
+  }
+
+  return {
+    props: {
+      nextPath: normalizeNextPath(query.next),
+    },
+  };
+};

--- a/apps/admin-dashboard/pages/login.tsx
+++ b/apps/admin-dashboard/pages/login.tsx
@@ -3,7 +3,7 @@ import type { GetServerSideProps } from 'next';
 import { useRouter } from 'next/router';
 import type { FormEvent } from 'react';
 import { useState } from 'react';
-import { getAdminSessionToken, normalizeNextPath } from '../lib/adminSession';
+import { getAdminSessionToken, normalizeNextPath } from '../lib/adminSessionShared';
 
 type LoginPageProps = {
   nextPath?: string;

--- a/apps/admin-dashboard/pages/reports/[id].tsx
+++ b/apps/admin-dashboard/pages/reports/[id].tsx
@@ -5,6 +5,7 @@ import { AppLayout } from '../../components/AppLayout';
 import { DetailCard } from '../../components/DetailCard';
 import { HistoryList } from '../../components/HistoryList';
 import { fetchAdminReport } from '../../lib/adminReports';
+import { withAdminPageAuth } from '../../lib/adminSession';
 import type { ReportDetail } from '../../lib/types';
 
 type ReportDetailPageProps = {
@@ -62,6 +63,7 @@ export default function ReportDetailPage({
 
 export const getServerSideProps: GetServerSideProps<ReportDetailPageProps> = async ({
   params,
+  ...context
 }) => {
   const id = typeof params?.id === 'string' ? params.id : undefined;
 
@@ -73,20 +75,31 @@ export const getServerSideProps: GetServerSideProps<ReportDetailPageProps> = asy
     };
   }
 
-  try {
-    const report = await fetchAdminReport(id);
+  return withAdminPageAuth<ReportDetailPageProps>(
+    {
+      params,
+      ...context,
+    } as never,
+    async (token) => {
+      try {
+        const report = await fetchAdminReport(id, token);
 
-    return {
-      props: {
-        report,
-      },
-    };
-  } catch (error) {
-    return {
-      props: {
-        errorMessage:
-          '通報詳細を取得できませんでした。Backend API の起動状態を確認してください。',
-      },
-    };
-  }
+        return {
+          props: {
+            report,
+          },
+        };
+      } catch (error) {
+        if (error instanceof Error && error.name === 'AdminSessionUnauthorizedError') {
+          throw error;
+        }
+        return {
+          props: {
+            errorMessage:
+              '通報詳細を取得できませんでした。Backend API の起動状態を確認してください。',
+          },
+        };
+      }
+    },
+  );
 };

--- a/apps/admin-dashboard/pages/unresolved.tsx
+++ b/apps/admin-dashboard/pages/unresolved.tsx
@@ -11,6 +11,7 @@ import {
   UNRESOLVED_REPORTED_THRESHOLD_HOURS,
   updateCollectionCandidate,
 } from '../lib/adminReports';
+import { withAdminPageAuth } from '../lib/adminSession';
 import type { ReportDetail } from '../lib/types';
 
 type UnresolvedPageProps = {
@@ -137,26 +138,38 @@ export default function UnresolvedPage({
 
 export const getServerSideProps: GetServerSideProps<UnresolvedPageProps> = async ({
   query = {},
+  ...context
 }) => {
   const selectedView = normalizeSelectedUnresolvedView(query.view);
 
-  try {
-    const reports = await fetchReportedCandidateReports();
+  return withAdminPageAuth<UnresolvedPageProps>(
+    {
+      query,
+      ...context,
+    } as never,
+    async (token) => {
+      try {
+        const reports = await fetchReportedCandidateReports(new Date(), token);
 
-    return {
-      props: {
-        reports,
-        selectedView,
-      },
-    };
-  } catch (error) {
-    return {
-      props: {
-        reports: [],
-        selectedView,
-        errorMessage:
-          '回収依頼候補を取得できませんでした。Backend API の起動状態を確認してください。',
-      },
-    };
-  }
+        return {
+          props: {
+            reports,
+            selectedView,
+          },
+        };
+      } catch (error) {
+        if (error instanceof Error && error.name === 'AdminSessionUnauthorizedError') {
+          throw error;
+        }
+        return {
+          props: {
+            reports: [],
+            selectedView,
+            errorMessage:
+              '回収依頼候補を取得できませんでした。Backend API の起動状態を確認してください。',
+          },
+        };
+      }
+    },
+  );
 };

--- a/apps/admin-dashboard/styles/globals.css
+++ b/apps/admin-dashboard/styles/globals.css
@@ -337,8 +337,8 @@ button:disabled {
   gap: 8px;
 }
 
+.form-field input,
 .form-field textarea {
-.form-field input {
   width: 100%;
   box-sizing: border-box;
   padding: 12px;

--- a/apps/admin-dashboard/styles/globals.css
+++ b/apps/admin-dashboard/styles/globals.css
@@ -14,6 +14,10 @@ body {
     sans-serif;
 }
 
+input {
+  box-sizing: border-box;
+}
+
 a {
   color: #0f5f4b;
   text-decoration: none;
@@ -334,11 +338,15 @@ button:disabled {
 }
 
 .form-field textarea {
+.form-field input {
   width: 100%;
   box-sizing: border-box;
   padding: 12px;
   border: 1px solid #cbd2d9;
   border-radius: 12px;
+}
+
+.form-field textarea {
   min-height: 120px;
   resize: vertical;
 }
@@ -390,6 +398,42 @@ button:disabled {
 .button-primary {
   background: #0f5f4b;
   color: #fff;
+}
+
+.auth-shell {
+  display: grid;
+  place-items: center;
+  min-height: 100%;
+  padding: 24px;
+}
+
+.auth-card {
+  width: min(100%, 420px);
+  padding: 28px;
+  border: 1px solid #d9e2ec;
+  border-radius: 24px;
+  background: rgba(255, 255, 255, 0.9);
+  box-shadow: 0 18px 40px rgba(15, 23, 42, 0.08);
+}
+
+.auth-card h1 {
+  margin: 0 0 12px;
+}
+
+.auth-form {
+  display: grid;
+  gap: 16px;
+  margin-top: 20px;
+}
+
+.auth-error {
+  margin: 0;
+  color: #8a341f;
+  font-weight: 700;
+}
+
+.auth-submit {
+  width: 100%;
 }
 
 .button-secondary {


### PR DESCRIPTION
## 概要
- admin-dashboard に管理者ログイン画面を追加
- HTTP-only cookie ベースで既存 SSR ページを認証保護
- 回収対象フラグ更新を認証付きの API route 経由に変更

## 変更内容
- `/login` ページと login/logout API route を追加
- 一覧、未解除、詳細、回収依頼、回収結果の各ページを未ログイン時にログインへリダイレクト
- AppLayout にログアウト導線を追加
- Jest を拡張してログイン、未認証リダイレクト、ログアウトを確認

## 確認
- `cd apps/admin-dashboard && npm test`
- `cd apps/admin-dashboard && npm run type-check`
- `cd apps/admin-dashboard && npm run lint`
- `cd apps/admin-dashboard && npm run build` はこの環境では generic な webpack error で失敗。Jest / typecheck / lint は通過。