### PR TITLE
管理画面ログインAPIの転送先を修正

### DIFF
--- a/apps/admin-dashboard/__tests__/SessionLoginApi.test.ts
+++ b/apps/admin-dashboard/__tests__/SessionLoginApi.test.ts
@@ -1,0 +1,64 @@
+import loginHandler from '../pages/api/session/login';
+
+describe('session login API', () => {
+  it('forwards login requests to the backend auth endpoint', async () => {
+    const originalFetch = global.fetch;
+    const fetchMock = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ accessToken: 'test-token' }),
+    } as Response);
+    global.fetch = fetchMock;
+
+    const req = {
+      method: 'POST',
+      body: {
+        email: 'admin@example.test',
+        password: 'password123',
+        next: '/unresolved',
+      },
+    };
+
+    const res = createMockResponse();
+
+    await loginHandler(req as never, res as never);
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'http://localhost:3000/auth/login',
+      expect.objectContaining({
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+        },
+      }),
+    );
+    expect(res.statusCode).toBe(200);
+    expect(res.jsonBody).toEqual({
+      ok: true,
+      redirectTo: '/unresolved',
+    });
+    expect(String(res.headers['Set-Cookie'])).toContain('admin_access_token=');
+
+    global.fetch = originalFetch;
+  });
+});
+
+function createMockResponse() {
+  const response = {
+    statusCode: 200,
+    headers: {} as Record<string, string | string[]>,
+    jsonBody: undefined as unknown,
+    setHeader(name: string, value: string | string[]) {
+      this.headers[name] = value;
+    },
+    status(code: number) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload: unknown) {
+      this.jsonBody = payload;
+      return this;
+    },
+  };
+
+  return response;
+}

--- a/apps/admin-dashboard/pages/api/session/login.ts
+++ b/apps/admin-dashboard/pages/api/session/login.ts
@@ -17,7 +17,7 @@ export default async function handler(
     return res.status(405).json({ error: 'Method Not Allowed' });
   }
 
-  const response = await fetch(`${getAdminApiBaseUrl()}/api/auth/login`, {
+  const response = await fetch(`${getAdminApiBaseUrl()}/auth/login`, {
     method: 'POST',
     headers: {
       'content-type': 'application/json',


### PR DESCRIPTION
## 概要
- admin-dashboard のログイン API route が backend の誤った endpoint を叩いていた問題を修正
- backend の正しい `/auth/login` へ転送するよう変更
- 転送先を固定で検証する回帰テストを追加

## 確認
- `TMPDIR=/tmp node /home/fjsn/github/NO-Houchi-Bicycle-Net/apps/admin-dashboard/node_modules/jest/bin/jest.js __tests__/SessionLoginApi.test.ts --runInBand`
- `TMPDIR=/tmp node /home/fjsn/github/NO-Houchi-Bicycle-Net/apps/admin-dashboard/node_modules/jest/bin/jest.js --runInBand`
- `node /home/fjsn/github/NO-Houchi-Bicycle-Net/apps/admin-dashboard/node_modules/typescript/bin/tsc --noEmit --incremental false`
- `node /home/fjsn/github/NO-Houchi-Bicycle-Net/apps/admin-dashboard/node_modules/next/dist/bin/next lint`
- `node /home/fjsn/github/NO-Houchi-Bicycle-Net/apps/admin-dashboard/node_modules/next/dist/bin/next build`
