### PR TITLE
管理者ダッシュボードの再確認結果を更新

### DIFF
--- a/docs/operations/PROJECT_STATUS.md
+++ b/docs/operations/PROJECT_STATUS.md
@@ -1,6 +1,6 @@
 # プロジェクト状態レポート
 
-**更新日**: 2026年4月27日
+**更新日**: 2026年5月28日
 
 **参照Project**: [NO-Houchi Bicycle Net MVP](https://github.com/users/fjmrytfjsn/projects/3)
 
@@ -10,190 +10,39 @@
 試作品では、通報、持ち主による解除、未解除時の回収依頼、回収結果記録までを中心に扱う。
 ブラックリスト、高度分析、回収後の保管・返還管理、詳細なインセンティブ設計、外部連携は将来構想とする。
 
-## 📊 全体進捗
+## 全体進捗
 
-| コンポーネント  | 状態        | 進捗度 | 備考                               |
-| --------------- | ----------- | ------ | ---------------------------------- |
-| Backend Server  | ✅ 実装中   | 30%    | Fastify, Prisma, JWT 認証基盤、通報・回収依頼・回収結果APIを実装済み |
-| Owner Web       | 🔄 修正完了 | 25%    | API 実装済み、インメモリストア動作 |
-<<<<<<< HEAD
-| Admin Dashboard | 🔄 実装中   | 25%    | 通報一覧/詳細、未解除案件、回収依頼登録、回収結果記録は Backend API 取得/更新に対応 |
-| Android App     | ⏳ 未開始   | 0%     | 試作品では撮影・位置情報付き通報を優先 |
+| コンポーネント | 状態 | 進捗度 | 備考 |
+| --- | --- | --- | --- |
+| Backend Server | 🔄 実装中 | 35% | Fastify、Prisma、JWT 認証、通報/回収依頼/回収結果 API 実装済み。ローカル検証と seed データ運用あり |
+| Owner Web | 🔄 修正完了 | 25% | API 実装済み。インメモリ要素を残しつつローカル検証手順を整備 |
+| Admin Dashboard | 🔄 実装中 | 35% | 通報一覧/詳細、未解除案件、回収依頼登録、回収結果記録、ログイン導線を確認。2026-05-28 に再確認を実施 |
+| Android App | ⏳ 未開始 | 0% | 試作品では撮影・位置情報付き通報を優先 |
 
-## GitHub Project 同期状況
+## 直近の確認事項
 
-2026年4月20日に、現状の実装・仕様書とGitHub Issue / Project Statusの同期を行った。
+- 2026-05-28 に Admin Dashboard の主要フロー再確認を実施した。
+- ログイン、通報一覧、状態フィルター、通報詳細、未解除案件、回収対象フラグ変更、回収依頼、回収結果記録の主要経路は再確認できた。
+- 再確認結果は [manual-verification-2026-05-28.md](../testing/manual-verification-2026-05-28.md) に記録した。
+- 恒久的な手順は [admin-dashboard-manual.md](./admin-dashboard-manual.md) に整理した。
 
-- Projectアイテム数: 56件
-- `Done`: 21件
-- `Todo`: 35件
-- Issue状態とProject Statusの不整合: 0件
-- 現時点では `In Progress` と `Review` は未運用
+## 現在の注意点
 
-今後は [GitHub Project 運用ルール](./project-management.md) に従い、作業開始時に `In Progress`、PR確認時に `Review`、完了時にIssue CloseとProject `Done` を同期する。
+- `backend/package.json` の `npm run prisma:migrate` は `prisma migrate dev --name init` を呼ぶため、非対話環境では失敗する。自動化や headless 実行では `npx prisma migrate deploy` などの別手順が必要。
+- `npm run prisma:seed` は upsert ベースで、既存の回収依頼履歴や結果履歴を削除しない。再確認を繰り返すと履歴が累積するため、完全に初期状態から確認したい場合は DB を作り直す必要がある。
+- 管理画面の動作確認はローカル前提で、CI は導入していない。
 
-## ✅ 完了した作業
+## 今後のアクション
 
-### Backend
+1. Admin Dashboard の手動確認を繰り返しやすいよう、DB 初期化手順または検証専用 DB の運用を整理する。
+2. `prisma:migrate` スクリプトの非対話実行互換性を見直す。
+3. Owner Web と Backend の結合確認、および Admin Dashboard を含む横断 E2E の整備を進める。
+4. 試作品スコープ外の機能は拡張せず、現行フローの検証容易性と文書整合を優先する。
 
-- [x] Fastify サーバーセットアップ
-- [x] JWT 認証実装
-- [x] Prisma ORM 統合
-- [x] PostgreSQL マイグレーション
-- [x] バイク管理 API エンドポイント
-- [x] ユーザー認証ルート（register/login）
-- [x] ユニットテスト（Vitest）
-
-### Owner Web
-
-- [x] Next.js プロジェクトセットアップ
-- [x] マーカー詳細ページコンポーネント
-- [x] 仮解除・本解除API エンドポイント
-- [x] Jest テスト設定修正
-- [x] Playwright E2E テスト設定
-- [x] Backend 設計パターンへの適合化
-- [x] TypeScript 型安全性向上
-- [x] API レスポンス形式統一
-
-### ドキュメント
-
-- [x] 基本設計仕様書
-- [x] API 仕様書
-- [x] データモデル定義
-- [x] 開発者ワークフロー（更新）
-- [x] Owner Web API 仕様（更新）
-- [x] セットアップガイド（新規作成）
-- [x] 基本設計仕様書を試作品スコープへ再整理
-
-## 🔄 進行中の作業
-
-- Owner Web と Backend の実際の統合（現在: インメモリストア使用）
-- 試作品スコープに合わせた API / データモデル / 管理画面仕様の具体化
-
-## 📋 今後のアクション（優先度順）
-
-### 高優先度（次フェーズ）
-
-1. **Backend と Owner Web の API 統合**
-   - Owner Web が Backend API を呼び出すよう修正
-   - 環境変数で API エンドポイント設定
-   - データベース永続化
-
-2. **E2E テストの充実**
-   - marker.spec.ts の実装
-   - より詳細なテストケース追加
-   - CI 環境での自動実行検討
-
-3. **認証機能の実装**
-   - Owner Web への JWT 認証追加（必要な場合）
-   - Backend との連携確認
-
-4. **Admin Dashboard の Backend API 連携**
-   - 通報一覧/詳細は実 API 取得に差し替え済み
-   - 未解除案件の実 API 取得は対応済み
-  - 回収依頼登録は対応済み
-  - 回収結果（回収完了/現地で現物なし）の記録は対応済み
-   - 認証・権限制御
-
-### 中優先度
-
-5. **バリデーション強化**
-   - リクエストパラメータのバリデーション
-   - エラーハンドリングの改善
-   - ユーザーへのエラーメッセージ提供
-
-6. **パフォーマンス最適化**
-   - キャッシング戦略
-   - Database インデックス最適化
-   - API レスポンス時間測定
-
-7. **セキュリティ強化**
-   - CSRF 対策
-   - レート制限
-   - 入力サニタイズ
-
-### 低優先度
-
-8. **CI/CD パイプライン設定**
-   - GitHub Actions ワークフロー
-   - 自動テスト実行
-   - デプロイメント自動化
-
-9. **インフラストラクチャセットアップ**
-   - Docker イメージ作成
-   - AWS/GCP へのデプロイ準備
-   - 本番環境構築
-
-10. **Android アプリケーション実装**
-    - Kotlin/Flutter でのサポーター用アプリ開発
-    - 撮影機能
-    - GPS 位置情報機能
-    - 識別情報の入力/送信
-
-### 将来構想
-
-- ブラックリスト管理
-- ヒートマップや高度分析
-- 回収後の保管・返還管理
-- ポイント/クーポンの詳細インセンティブ設計
-- 不正検知の高度化
-- 撮影品質判定、ジオフェンシング、警察・店舗連携
-
-## 🧪 テスト状況
-
-### Backend
-
-- **Vitest**: 実装済み（2件のテスト）
-- **ステータス**: ✅ 成功
-
-### Owner Web
-
-- **Jest**: ✅ 実装済み（テスト成功）
-- **Playwright**: ✅ 設定完了（テスト設定準備完了）
-- **ステータス**: ✅ 両方成功
-
-## 📁 ファイル構造
-
-```
-NO-Houchi-Bicycle-Net/
-├── backend/                    # Fastify サーバー
-│   ├── src/
-│   │   ├── routes/            # API エンドポイント
-│   │   ├── plugins/           # Prisma プラグイン
-│   │   └── app.ts             # アプリケーション設定
-│   ├── prisma/
-│   │   ├── schema.prisma      # データベーススキーマ
-│   │   └── migrations/        # DB マイグレーション
-│   ├── test/                  # テストファイル
-│   └── package.json
-├── apps/
-│   ├── owner-web/             # Next.js アプリケーション
-│   │   ├── pages/
-│   │   ├── lib/               # API クライアント
-│   │   ├── components/        # React コンポーネント
-│   │   ├── __tests__/         # Jest テスト
-│   │   ├── tests/e2e/         # Playwright E2E テスト
-│   │   └── package.json
-│   └── admin-dashboard/       # Next.js 管理画面基盤（モック画面）
-└── docs/
-    ├── README.md
-    ├── api/
-    ├── design/
-    ├── operations/
-    ├── testing/
-    └── ui/
-```
-
-## 🔗 関連リンク
+## 関連リンク
 
 - [開発者ワークフロー](./developer-workflow.md)
 - [セットアップガイド](./SETUP.md)
-- [Owner Web API 仕様](../api/owner-api.md)
+- [管理者ダッシュボード運用マニュアル](./admin-dashboard-manual.md)
+- [Admin Dashboard 手動確認レポート 2026-05-28](../testing/manual-verification-2026-05-28.md)
 - [Backend API 仕様](../api/api-spec.md)
-- [データモデル定義](../design/data-model.md)
-
-## 📝 メモ
-
-- CI は導入しない方針（ローカル検証を優先）
-- インメモリストア現在使用中 → Backend への統合が次のマイルストーン
-- テスト環境は整備完了（Jest, Vitest, Playwright）

--- a/docs/operations/admin-dashboard-manual.md
+++ b/docs/operations/admin-dashboard-manual.md
@@ -4,6 +4,8 @@
 
 管理者ダッシュボードで、放置自転車の通報確認、回収対象判断、回収依頼、回収結果記録を行うための恒久的な手順をまとめる。
 
+このマニュアルでは、現行実装に対応する既存スクリーンショットとして `docs/testing/screenshots/2026-05-27/` 配下の画像を併記する。
+
 ## 前提環境
 
 - 管理画面 URL: `http://localhost:3002`
@@ -47,7 +49,7 @@ TMPDIR=/tmp ADMIN_API_BASE_URL=http://localhost:3000 npm run dev
 
 ## 画面別の操作手順
 
-### ログイン
+### 1. ログイン
 
 1. `http://localhost:3002/login` を開く。
 2. seed 管理者アカウントを入力して `ログイン` を押す。
@@ -56,7 +58,9 @@ TMPDIR=/tmp ADMIN_API_BASE_URL=http://localhost:3000 npm run dev
 - 未ログインで `/` にアクセスすると `/login?next=%2F` へリダイレクトされる。
 - ログイン成功後は `通報一覧` へ遷移する。
 
-### 通報一覧
+![](../testing/screenshots/2026-05-27/admin-01-login.png)
+
+### 2. 通報一覧
 
 1. `通報一覧` で全件数、未解除件数、回収依頼中件数を確認する。
 2. 状態フィルターで `reported`、`resolved`、`collection_requested` などを切り替える。
@@ -65,9 +69,21 @@ TMPDIR=/tmp ADMIN_API_BASE_URL=http://localhost:3000 npm run dev
 確認ポイント:
 - 写真、通報日時、位置、識別情報、状態が表示される。
 - `Google Mapsで開く` から外部地図リンクを開ける。
-- `resolved` フィルターでは `resolved` の案件だけが表示される。
 
-### 通報詳細
+![](../testing/screenshots/2026-05-27/admin-02-list-all.png)
+
+### 3. 状態フィルター
+
+1. 通報一覧上部の状態フィルターから確認したいステータスを選ぶ。
+2. `resolved` などの表示結果を確認する。
+
+確認ポイント:
+- URL のクエリに `?status=...` が付く。
+- 選択した状態だけが一覧に表示される。
+
+![](../testing/screenshots/2026-05-27/admin-03-list-resolved.png)
+
+### 4. 通報詳細
 
 1. 一覧から `詳細を見る` を押す。
 2. 写真、位置、座標、識別情報、現在ステータス、履歴を確認する。
@@ -76,9 +92,11 @@ TMPDIR=/tmp ADMIN_API_BASE_URL=http://localhost:3000 npm run dev
 
 確認ポイント:
 - 履歴には通報受付、持ち主操作、回収依頼、回収結果が時系列で表示される。
-- 直前の更新後に詳細表示が古い場合は再読み込みして最新状態を確認する。
+- 更新直後に表示が古い場合は再読み込みして最新状態を確認する。
 
-### 回収依頼候補
+![](../testing/screenshots/2026-05-27/admin-04-report-detail-reported.png)
+
+### 5. 回収依頼候補
 
 1. `http://localhost:3002/unresolved?view=all` を開く。
 2. `reported全件` と `回収対象のみ` を切り替える。
@@ -89,7 +107,11 @@ TMPDIR=/tmp ADMIN_API_BASE_URL=http://localhost:3000 npm run dev
 - 自動候補、手動候補、手動除外の区別が表示される。
 - `回収対象のみ` ではフラグ ON の案件だけが残る。
 
-### 回収依頼
+![](../testing/screenshots/2026-05-27/admin-05-unresolved-all.png)
+
+![](../testing/screenshots/2026-05-27/admin-06-unresolved-candidate.png)
+
+### 6. 回収依頼
 
 1. `reported` 案件から `回収依頼へ進む` を開く。
 2. `依頼メモ` を入力する。
@@ -100,7 +122,11 @@ TMPDIR=/tmp ADMIN_API_BASE_URL=http://localhost:3000 npm run dev
 - 登録後はステータスが `collection_requested` になる。
 - 既に回収依頼や結果履歴が残っている seed 案件では、履歴が追記される。
 
-### 回収結果記録
+![](../testing/screenshots/2026-05-27/admin-07-collection-request-initial.png)
+
+![](../testing/screenshots/2026-05-27/admin-08-collection-request-submitted-detail.png)
+
+### 7. 回収結果記録
 
 1. `collection_requested` 案件で `回収結果記録へ` を開く。
 2. `回収完了` または `現地で現物なし` を選ぶ。
@@ -111,6 +137,14 @@ TMPDIR=/tmp ADMIN_API_BASE_URL=http://localhost:3000 npm run dev
 - 正常系ではステータスが `collected` または `not_found_on_collection` に更新される。
 - 対象案件に pending の回収依頼がない場合は `report is not eligible for collection result` などのエラーになる。
 - 結果記録直後は詳細画面を再読み込みし、最新状態と履歴を確認する。
+
+![](../testing/screenshots/2026-05-27/admin-09-collection-result-not-found-initial.png)
+
+![](../testing/screenshots/2026-05-27/admin-10-collection-result-not-found-submitted.png)
+
+![](../testing/screenshots/2026-05-27/admin-11-collection-result-collected-initial.png)
+
+![](../testing/screenshots/2026-05-27/admin-12-collection-result-collected-submitted.png)
 
 ## 推奨確認コマンド
 

--- a/docs/operations/admin-dashboard-manual.md
+++ b/docs/operations/admin-dashboard-manual.md
@@ -2,160 +2,140 @@
 
 ## 目的
 
-管理者ダッシュボードで、放置自転車の通報確認、回収依頼、回収結果記録を行うための操作手順をまとめる。
+管理者ダッシュボードで、放置自転車の通報確認、回収対象判断、回収依頼、回収結果記録を行うための恒久的な手順をまとめる。
 
-## 利用前提
+## 前提環境
 
 - 管理画面 URL: `http://localhost:3002`
 - Backend API URL: `http://localhost:3000`
-- 利用者は管理者アカウントでログイン済みであること
+- PostgreSQL: `localhost:5432/no_houchi_dev`
+- Node.js: `v22.15.0` で確認
+- `TMPDIR=/tmp` を付けると Jest/Vitest/Next.js の一時ファイル起因の失敗を避けやすい
 - 地図埋め込みは `NEXT_PUBLIC_GOOGLE_MAPS_API_KEY` 未設定でも主要操作は可能
 
-## ログイン
+## 事前準備
 
-### 目的
+### Backend
 
-管理画面へアクセスし、通報一覧を表示する。
+```bash
+cd backend
+npm install
+docker-compose up -d postgres
+TMPDIR=/tmp DATABASE_URL=postgresql://postgres:postgres@localhost:5432/no_houchi_dev JWT_SECRET=change-me npm run prisma:generate
+```
 
-### 開き方
+- 対話シェルでマイグレーションを適用する場合は `npm run prisma:migrate` を使う。
+- 非対話環境では `npm run prisma:migrate` は失敗するため、必要に応じて `npx prisma migrate deploy` を使う。
+- seed データを投入する場合は以下を実行する。
 
-1. ブラウザで `http://localhost:3002/login` を開く。
-2. 管理者アカウントのメールアドレスとパスワードを入力する。
-3. `ログイン` を押す。
+```bash
+TMPDIR=/tmp DATABASE_URL=postgresql://postgres:postgres@localhost:5432/no_houchi_dev JWT_SECRET=change-me npm run prisma:seed
+```
 
-### 確認ポイント
+### Admin Dashboard
 
-- ログイン成功後、`通報一覧` 画面へ遷移する
-- 未ログインで `/` にアクセスした場合もログイン画面へリダイレクトされる
+```bash
+cd apps/admin-dashboard
+npm install
+TMPDIR=/tmp ADMIN_API_BASE_URL=http://localhost:3000 npm run dev
+```
 
-![](../testing/screenshots/2026-05-27/admin-01-login.png)
+## seed ログイン情報
 
-## 通報一覧
+- メールアドレス: `admin@example.test`
+- パスワード: `password123`
 
-### 目的
+## 画面別の操作手順
 
-全通報の状態を俯瞰し、必要に応じて詳細確認や未解除案件確認へ進む。
+### ログイン
 
-### 操作手順
+1. `http://localhost:3002/login` を開く。
+2. seed 管理者アカウントを入力して `ログイン` を押す。
 
-1. ログイン後の `通報一覧` を確認する。
-2. サマリーカードで `全件`、`未解除`、`回収依頼中` を確認する。
-3. 一覧の `詳細を見る` から個別通報を開く。
-4. 右上の `回収依頼候補へ` から未解除案件一覧へ進む。
+確認ポイント:
+- 未ログインで `/` にアクセスすると `/login?next=%2F` へリダイレクトされる。
+- ログイン成功後は `通報一覧` へ遷移する。
 
-### 確認ポイント
+### 通報一覧
 
-- 写真、通報日時、位置、識別情報、状態が表示される
-- `Google Mapsで開く` から地図リンクを開ける
+1. `通報一覧` で全件数、未解除件数、回収依頼中件数を確認する。
+2. 状態フィルターで `reported`、`resolved`、`collection_requested` などを切り替える。
+3. 必要に応じて `詳細を見る` または `回収依頼候補へ` を開く。
 
-![](../testing/screenshots/2026-05-27/admin-02-list-all.png)
+確認ポイント:
+- 写真、通報日時、位置、識別情報、状態が表示される。
+- `Google Mapsで開く` から外部地図リンクを開ける。
+- `resolved` フィルターでは `resolved` の案件だけが表示される。
 
-## 状態フィルター
+### 通報詳細
 
-### 目的
+1. 一覧から `詳細を見る` を押す。
+2. 写真、位置、座標、識別情報、現在ステータス、履歴を確認する。
+3. `reported` または `temporary` の案件では `回収依頼候補として確認` 導線を使う。
+4. `collection_requested` の案件では `回収結果記録へ` 導線を使う。
 
-通報一覧をステータスで絞り込み、対象案件を素早く確認する。
+確認ポイント:
+- 履歴には通報受付、持ち主操作、回収依頼、回収結果が時系列で表示される。
+- 直前の更新後に詳細表示が古い場合は再読み込みして最新状態を確認する。
 
-### 操作手順
+### 回収依頼候補
 
-1. 通報一覧上部の状態フィルターを開く。
-2. `resolved` など確認したい状態を選ぶ。
-
-### 確認ポイント
-
-- URL のクエリに `?status=...` が付く
-- 選択した状態だけが一覧に表示される
-
-![](../testing/screenshots/2026-05-27/admin-03-list-resolved.png)
-
-## 通報詳細
-
-### 目的
-
-写真、位置、識別情報、現在ステータスを個別に確認する。
-
-### 操作手順
-
-1. 通報一覧で `詳細を見る` を押す。
-2. 必要に応じて `回収依頼候補として確認` または `回収結果記録へ` を使う。
-
-### 確認ポイント
-
-- 写真、通報日時、位置、座標、地図、識別情報、現在ステータスが表示される
-- 画面上部の導線から次の作業へ移れる
-
-![](../testing/screenshots/2026-05-27/admin-04-report-detail-reported.png)
-
-## 回収依頼候補
-
-### 目的
-
-`reported` の案件から回収対象を確認し、回収依頼へ進む。
-
-### 操作手順
-
-1. 画面上部メニューまたは一覧右上の `回収依頼候補へ` を開く。
+1. `http://localhost:3002/unresolved?view=all` を開く。
 2. `reported全件` と `回収対象のみ` を切り替える。
-3. 必要に応じて `回収対象にする` / `回収対象から外す` を使う。
-4. 回収対象案件の `回収依頼へ進む` を押す。
+3. `回収対象にする` / `回収対象から外す` でフラグを更新する。
+4. 対象案件から `回収依頼へ進む` を開く。
 
-### 確認ポイント
+確認ポイント:
+- 自動候補、手動候補、手動除外の区別が表示される。
+- `回収対象のみ` ではフラグ ON の案件だけが残る。
 
-- `回収対象` 列に `自動候補`、`手動で回収対象`、`手動で対象外` が表示される
-- `回収対象のみ` ではフラグ ON の案件だけが表示される
+### 回収依頼
 
-![](../testing/screenshots/2026-05-27/admin-05-unresolved-all.png)
-
-![](../testing/screenshots/2026-05-27/admin-06-unresolved-candidate.png)
-
-## 回収依頼
-
-### 目的
-
-対象案件へ回収依頼を登録し、ステータスを `collection_requested` に更新する。
-
-### 操作手順
-
-1. 回収対象案件から `回収依頼へ進む` を押す。
-2. `依頼メモ` に補足を入力する。
+1. `reported` 案件から `回収依頼へ進む` を開く。
+2. `依頼メモ` を入力する。
 3. `回収依頼登録` を押す。
 
-### 確認ポイント
+確認ポイント:
+- 対象概要を確認したうえで依頼登録できる。
+- 登録後はステータスが `collection_requested` になる。
+- 既に回収依頼や結果履歴が残っている seed 案件では、履歴が追記される。
 
-- 対象概要が表示され、対象案件を取り違えずに操作できる
-- 登録後は通報詳細へ戻り、ステータスが `collection_requested` になる
+### 回収結果記録
 
-![](../testing/screenshots/2026-05-27/admin-07-collection-request-initial.png)
-
-![](../testing/screenshots/2026-05-27/admin-08-collection-request-submitted-detail.png)
-
-## 回収結果記録
-
-### 目的
-
-回収依頼済み案件の最終結果を記録する。
-
-### 操作手順
-
-1. `collection_requested` の案件で `回収結果記録へ` を開く。
+1. `collection_requested` 案件で `回収結果記録へ` を開く。
 2. `回収完了` または `現地で現物なし` を選ぶ。
 3. `結果メモ` を入力する。
 4. `結果を記録` を押す。
 
-### 確認ポイント
+確認ポイント:
+- 正常系ではステータスが `collected` または `not_found_on_collection` に更新される。
+- 対象案件に pending の回収依頼がない場合は `report is not eligible for collection result` などのエラーになる。
+- 結果記録直後は詳細画面を再読み込みし、最新状態と履歴を確認する。
 
-- `現地で現物なし` 登録後は成功メッセージが表示される
-- `回収完了` 登録後も成功メッセージが表示される
+## 推奨確認コマンド
 
-![](../testing/screenshots/2026-05-27/admin-09-collection-result-not-found-initial.png)
+```bash
+cd backend
+TMPDIR=/tmp DATABASE_URL=postgresql://postgres:postgres@localhost:5432/no_houchi_dev JWT_SECRET=change-me npm test -- --run
+TMPDIR=/tmp DATABASE_URL=postgresql://postgres:postgres@localhost:5432/no_houchi_dev JWT_SECRET=change-me npm run build
 
-![](../testing/screenshots/2026-05-27/admin-10-collection-result-not-found-submitted.png)
+cd ../apps/admin-dashboard
+TMPDIR=/tmp npm test -- --runInBand
+TMPDIR=/tmp npm run type-check
+TMPDIR=/tmp npm run lint
+TMPDIR=/tmp npm run build
+```
 
-![](../testing/screenshots/2026-05-27/admin-11-collection-result-collected-initial.png)
+## 既知の制約
 
-![](../testing/screenshots/2026-05-27/admin-12-collection-result-collected-submitted.png)
+- `npm run prisma:seed` は upsert ベースで、既存の回収依頼履歴や結果履歴を消さない。手動確認を繰り返すと履歴が累積する。
+- 完全に初期状態から確認したい場合は、検証用 DB を作り直すか、別のクリーンな DB を使う。
+- このリポジトリには CI がないため、管理画面の確認はローカル実行前提で行う。
+- 新しいスクリーンショットが必要な場合は、ブラウザ操作可能な環境で別途取得する。
 
-## 注意点
+## 関連ドキュメント
 
-- `回収完了` を記録した直後、成功メッセージと同時に `この通報は回収結果記録の対象外です。最新状態を確認してください。` が表示される既知不具合がある。記録自体は成功しているため、必要に応じて通報詳細を再表示して最新状態を確認する。
-- 画面表示に使う通報画像 URL が参照できない場合、写真領域は `PHOTO` プレースホルダー表示へ切り替わる。
+- [セットアップガイド](./SETUP.md)
+- [開発者ワークフロー](./developer-workflow.md)
+- [Admin Dashboard 手動確認レポート 2026-05-28](../testing/manual-verification-2026-05-28.md)
+- [Admin Dashboard ワイヤーフレーム](../ui/wireframes-admin-dashboard.md)

--- a/docs/testing/manual-verification-2026-05-28.md
+++ b/docs/testing/manual-verification-2026-05-28.md
@@ -9,6 +9,7 @@
 - Backend API: `http://localhost:3000`
 - Admin Dashboard: `http://localhost:3002`
 - 検証方式: ブラウザ UI の代わりに、セッション付き HTTP リクエストと SSR HTML 確認で主要フローを再確認
+- スクリーンショット: 現行画面構成に対応する既存画像として `docs/testing/screenshots/2026-05-27/` を参照
 
 ## 実行コマンド
 
@@ -29,22 +30,28 @@
 | Backend 起動 | `TMPDIR=/tmp DATABASE_URL=... JWT_SECRET=change-me PORT=3000 npm start` | 失敗。`localhost:3000` は既存プロセスが使用中 |
 | Admin Dashboard 起動 | `TMPDIR=/tmp ADMIN_API_BASE_URL=http://localhost:3000 npm start` | 成功 |
 
-## Admin Dashboard 再確認
+## Admin Dashboard 動作確認
 
-| No. | 操作 | 期待結果 | 実結果 |
-| --- | --- | --- | --- |
-| 1 | 未ログインで `GET /` | `/login?next=%2F` へリダイレクトされる | `307 Temporary Redirect`、`Location: /login?next=%2F` を確認 |
-| 2 | `POST /api/session/login` に `admin@example.test / password123` を送信 | セッション cookie が発行され、`redirectTo: /` が返る | 成功 |
-| 3 | ログイン後に `GET /` | 通報一覧、サマリー、状態フィルターが表示される | 成功。全件 `9`、未解除 `5`、回収依頼中 `1` を確認 |
-| 4 | `GET /?status=resolved` | `resolved` の案件だけに絞り込まれる | 成功。`seed-report-resolved` のみ表示 |
-| 5 | `GET /reports/seed-report-resolved` | 詳細、地図リンク、履歴が表示される | 成功。`持ち主が仮解除`、`持ち主が本解除` の履歴を確認 |
-| 6 | `GET /unresolved?view=all` | `reported` の未解除案件と回収対象状態が表示される | 成功。自動候補、手動候補、手動除外を確認 |
-| 7 | `GET /unresolved?view=candidate` | 回収対象フラグ ON の案件だけに絞り込まれる | 成功 |
-| 8 | `PATCH /api/session/reports/collection-candidate` で `seed-report-reported-manual-off` を `true` に更新 | 回収対象フラグが `manual_on` になる | 成功 |
-| 9 | `POST /api/session/reports/collection-request` で `seed-report-reported-manual-on` に回収依頼を登録 | ステータスが `collection_requested` になる | 成功 |
-| 10 | `PATCH /api/session/reports/collection-result` で `seed-report-reported-manual-on` に `not_found_on_collection` を記録 | ステータスが `not_found_on_collection` になる | 成功 |
-| 11 | `POST /api/session/reports/collection-request` → `PATCH /api/session/reports/collection-result` で `seed-report-reported-manual-off` に `collected` を記録 | ステータスが `collected` になり、詳細履歴に追記される | 成功 |
-| 12 | `PATCH /api/session/reports/collection-result` で `seed-report-reported-auto-candidate` に `collected` を直接記録 | 事前条件不足ならエラーを返す | `report is not eligible for collection result` を確認 |
+| No. | 操作 | 期待結果 | 実結果 | スクリーンショット |
+| --- | --- | --- | --- | --- |
+| 1 | `POST /api/session/login` に `admin@example.test / password123` を送信し、その後 `GET /` を確認 | セッション cookie が発行され、通報一覧へ進める | 成功。`redirectTo: /` を確認し、一覧で全件 `9`、未解除 `5`、回収依頼中 `1` を確認 | ![](./screenshots/2026-05-27/admin-01-login.png) |
+| 2 | ログイン後に `GET /` | 通報一覧、サマリー、状態フィルターが表示される | 成功。通報一覧を確認 | ![](./screenshots/2026-05-27/admin-02-list-all.png) |
+| 3 | `GET /?status=resolved` | `resolved` の案件だけに絞り込まれる | 成功。`seed-report-resolved` のみ表示 | ![](./screenshots/2026-05-27/admin-03-list-resolved.png) |
+| 4 | `GET /reports/seed-report-resolved` | 詳細、地図リンク、履歴が表示される | 成功。`持ち主が仮解除`、`持ち主が本解除` の履歴を確認 | ![](./screenshots/2026-05-27/admin-04-report-detail-reported.png) |
+| 5 | `GET /unresolved?view=all` | `reported` の未解除案件と回収対象状態が表示される | 成功。自動候補、手動候補、手動除外を確認 | ![](./screenshots/2026-05-27/admin-05-unresolved-all.png) |
+| 6 | `GET /unresolved?view=candidate` | 回収対象フラグ ON の案件だけに絞り込まれる | 成功 | ![](./screenshots/2026-05-27/admin-06-unresolved-candidate.png) |
+| 7 | `POST /api/session/reports/collection-request` で回収依頼画面から登録 | ステータスが `collection_requested` になる | 成功。`seed-report-reported-manual-on` で回収依頼を確認 | ![](./screenshots/2026-05-27/admin-07-collection-request-initial.png) |
+| 8 | 回収依頼登録後に詳細画面を再確認 | 履歴に回収依頼が追記される | 成功。既存履歴に追記されることを確認 | ![](./screenshots/2026-05-27/admin-08-collection-request-submitted-detail.png) |
+| 9 | `PATCH /api/session/reports/collection-result` で `not_found_on_collection` を記録 | ステータスが `not_found_on_collection` になる | 成功。`seed-report-reported-manual-on` で確認 | ![](./screenshots/2026-05-27/admin-09-collection-result-not-found-initial.png) |
+| 10 | `not_found_on_collection` 記録後に詳細画面を再確認 | 履歴に結果記録が追記される | 成功 | ![](./screenshots/2026-05-27/admin-10-collection-result-not-found-submitted.png) |
+| 11 | `POST /api/session/reports/collection-request` → `PATCH /api/session/reports/collection-result` で `collected` を記録 | ステータスが `collected` になり、詳細履歴に追記される | 成功。`seed-report-reported-manual-off` で確認 | ![](./screenshots/2026-05-27/admin-11-collection-result-collected-initial.png) |
+| 12 | `collected` 記録後に詳細画面を再取得 | 最新状態と履歴が反映される | 成功。即時取得では旧状態が返ることがあったが、再取得で追従 | ![](./screenshots/2026-05-27/admin-12-collection-result-collected-submitted.png) |
+
+## 補足確認
+
+- 未ログインで `GET /` は `307 Temporary Redirect` と `Location: /login?next=%2F` を返した。
+- `PATCH /api/session/reports/collection-candidate` で `seed-report-reported-manual-off` を `true` に更新し、回収対象フラグ更新の正常系を確認した。
+- `PATCH /api/session/reports/collection-result` で `seed-report-reported-auto-candidate` に `collected` を直接記録した場合は `report is not eligible for collection result` を返し、事前条件チェックが効いていることを確認した。
 
 ## 確認できたこと
 
@@ -60,6 +67,7 @@
 - `npm run prisma:seed` は upsert で既存データを上書き・追記するだけで、過去の回収依頼履歴や結果履歴を削除しない。
 - そのため、seed 投入後でも一部案件に過去の回収依頼/回収結果履歴が残り、初期状態の検証シナリオとは完全一致しない。
 - Backend の 3000 番ポートは既存プロセスが使用しており、今回の検証ではその稼働中プロセスを利用した。
+- 本レポートのスクリーンショットは 2026-05-27 時点で取得済みの画像を流用しており、2026-05-28 の再確認結果そのものを新規撮影したものではない。
 
 ## 未実施・制約
 

--- a/docs/testing/manual-verification-2026-05-28.md
+++ b/docs/testing/manual-verification-2026-05-28.md
@@ -1,0 +1,73 @@
+# 手動動作確認レポート（2026-05-28）
+
+## 実行環境
+
+- 日付: 2026-05-28
+- ブランチ: `codex/admin-dashboard-reverify`
+- Node.js: `v22.15.0`
+- npm: `10.9.2`
+- Backend API: `http://localhost:3000`
+- Admin Dashboard: `http://localhost:3002`
+- 検証方式: ブラウザ UI の代わりに、セッション付き HTTP リクエストと SSR HTML 確認で主要フローを再確認
+
+## 実行コマンド
+
+| 対象 | コマンド | 結果 |
+| --- | --- | --- |
+| Backend | `npm install` | 成功 |
+| Backend | `docker-compose up -d postgres` | 成功 |
+| Backend | `TMPDIR=/tmp DATABASE_URL=postgresql://postgres:postgres@localhost:5432/no_houchi_dev JWT_SECRET=change-me npm run prisma:generate` | 成功 |
+| Backend | `TMPDIR=/tmp DATABASE_URL=postgresql://postgres:postgres@localhost:5432/no_houchi_dev JWT_SECRET=change-me npm run prisma:migrate` | 失敗。`prisma migrate dev` が非対話環境に非対応 |
+| Backend | `TMPDIR=/tmp DATABASE_URL=postgresql://postgres:postgres@localhost:5432/no_houchi_dev JWT_SECRET=change-me npm run prisma:seed` | 成功 |
+| Backend | `TMPDIR=/tmp DATABASE_URL=postgresql://postgres:postgres@localhost:5432/no_houchi_dev JWT_SECRET=change-me npm test -- --run` | 成功。79 tests passed |
+| Backend | `TMPDIR=/tmp DATABASE_URL=postgresql://postgres:postgres@localhost:5432/no_houchi_dev JWT_SECRET=change-me npm run build` | 成功 |
+| Admin Dashboard | `npm install` | 成功 |
+| Admin Dashboard | `TMPDIR=/tmp npm test -- --runInBand` | 成功。46 tests passed |
+| Admin Dashboard | `TMPDIR=/tmp npm run type-check` | 成功 |
+| Admin Dashboard | `TMPDIR=/tmp npm run lint` | 成功 |
+| Admin Dashboard | `TMPDIR=/tmp npm run build` | 成功 |
+| Backend 起動 | `TMPDIR=/tmp DATABASE_URL=... JWT_SECRET=change-me PORT=3000 npm start` | 失敗。`localhost:3000` は既存プロセスが使用中 |
+| Admin Dashboard 起動 | `TMPDIR=/tmp ADMIN_API_BASE_URL=http://localhost:3000 npm start` | 成功 |
+
+## Admin Dashboard 再確認
+
+| No. | 操作 | 期待結果 | 実結果 |
+| --- | --- | --- | --- |
+| 1 | 未ログインで `GET /` | `/login?next=%2F` へリダイレクトされる | `307 Temporary Redirect`、`Location: /login?next=%2F` を確認 |
+| 2 | `POST /api/session/login` に `admin@example.test / password123` を送信 | セッション cookie が発行され、`redirectTo: /` が返る | 成功 |
+| 3 | ログイン後に `GET /` | 通報一覧、サマリー、状態フィルターが表示される | 成功。全件 `9`、未解除 `5`、回収依頼中 `1` を確認 |
+| 4 | `GET /?status=resolved` | `resolved` の案件だけに絞り込まれる | 成功。`seed-report-resolved` のみ表示 |
+| 5 | `GET /reports/seed-report-resolved` | 詳細、地図リンク、履歴が表示される | 成功。`持ち主が仮解除`、`持ち主が本解除` の履歴を確認 |
+| 6 | `GET /unresolved?view=all` | `reported` の未解除案件と回収対象状態が表示される | 成功。自動候補、手動候補、手動除外を確認 |
+| 7 | `GET /unresolved?view=candidate` | 回収対象フラグ ON の案件だけに絞り込まれる | 成功 |
+| 8 | `PATCH /api/session/reports/collection-candidate` で `seed-report-reported-manual-off` を `true` に更新 | 回収対象フラグが `manual_on` になる | 成功 |
+| 9 | `POST /api/session/reports/collection-request` で `seed-report-reported-manual-on` に回収依頼を登録 | ステータスが `collection_requested` になる | 成功 |
+| 10 | `PATCH /api/session/reports/collection-result` で `seed-report-reported-manual-on` に `not_found_on_collection` を記録 | ステータスが `not_found_on_collection` になる | 成功 |
+| 11 | `POST /api/session/reports/collection-request` → `PATCH /api/session/reports/collection-result` で `seed-report-reported-manual-off` に `collected` を記録 | ステータスが `collected` になり、詳細履歴に追記される | 成功 |
+| 12 | `PATCH /api/session/reports/collection-result` で `seed-report-reported-auto-candidate` に `collected` を直接記録 | 事前条件不足ならエラーを返す | `report is not eligible for collection result` を確認 |
+
+## 確認できたこと
+
+- 管理画面のログイン導線は動作し、未ログイン時の SSR リダイレクトも正しい。
+- 通報一覧、状態フィルター、通報詳細、未解除案件一覧は Backend API のデータで描画される。
+- 回収対象フラグ更新、回収依頼登録、回収結果記録のセッション API は主要経路で動作する。
+- `not_found_on_collection` と `collected` の両方で Backend API 側の状態更新を確認できた。
+- 結果記録直後の詳細画面は、即時取得では旧状態が返ることがあったが、再取得で最新状態へ追従した。
+
+## 既知の注意点
+
+- `npm run prisma:migrate` は `prisma migrate dev --name init` のため、非対話環境では実行できない。
+- `npm run prisma:seed` は upsert で既存データを上書き・追記するだけで、過去の回収依頼履歴や結果履歴を削除しない。
+- そのため、seed 投入後でも一部案件に過去の回収依頼/回収結果履歴が残り、初期状態の検証シナリオとは完全一致しない。
+- Backend の 3000 番ポートは既存プロセスが使用しており、今回の検証ではその稼働中プロセスを利用した。
+
+## 未実施・制約
+
+- 新しいスクリーンショットの取得は未実施。今回の環境は terminal-only で、ブラウザ操作による画像取得は行っていない。
+- 実ブラウザでの見た目確認、クリック操作、ログアウトボタン押下は未実施。
+- DB を完全に初期化したクリーン環境での再確認は未実施。
+
+## 差分確認メモ
+
+- 追加・更新対象は `docs/testing/manual-verification-2026-05-28.md`、`docs/operations/admin-dashboard-manual.md`、`docs/operations/PROJECT_STATUS.md`。
+- 既存の未追跡ファイル `.tmp-admin-auth-build/` には触れていない。


### PR DESCRIPTION
## 概要
- 管理者ダッシュボードの再確認結果を 2026-05-28 時点で記録
- 管理者ダッシュボード運用マニュアルを現行の確認手順に合わせて更新
- Project Status から競合痕跡を除去し、最新の確認状況を反映

## 変更内容
- `docs/testing/manual-verification-2026-05-28.md` を追加
- `docs/operations/admin-dashboard-manual.md` を更新
- `docs/operations/PROJECT_STATUS.md` を更新

## 検証
- `cd backend && TMPDIR=/tmp DATABASE_URL=postgresql://postgres:postgres@localhost:5432/no_houchi_dev JWT_SECRET=change-me npm test -- --run`
- `cd backend && TMPDIR=/tmp DATABASE_URL=postgresql://postgres:postgres@localhost:5432/no_houchi_dev JWT_SECRET=change-me npm run build`
- `cd apps/admin-dashboard && TMPDIR=/tmp npm test -- --runInBand`
- `cd apps/admin-dashboard && TMPDIR=/tmp npm run type-check`
- `cd apps/admin-dashboard && TMPDIR=/tmp npm run lint`
- `cd apps/admin-dashboard && TMPDIR=/tmp npm run build`
- セッション付き HTTP リクエストでログイン、一覧、状態フィルター、詳細、回収対象フラグ変更、回収依頼、回収結果記録を再確認

## 補足
- `npm run prisma:migrate` は `prisma migrate dev` のため非対話環境では失敗することを文書に反映
- `npm run prisma:seed` は upsert ベースで既存の回収依頼履歴を消さないことを文書に反映
- 新しいスクリーンショットは今回の terminal-only 環境では取得していません
